### PR TITLE
fix: add HSTS and Content-Security-Policy headers

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,18 @@ const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
 const nextConfig: NextConfig = {
   async headers() {
+    const csp = [
+      "default-src 'self'",
+      // unsafe-inline required for Next.js inline scripts (e.g. theme init) and Tailwind
+      "script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: https:",
+      // next/font self-hosts Google Fonts — no external font-src needed
+      "font-src 'self'",
+      "connect-src 'self' https://vitals.vercel-insights.com https://va.vercel-scripts.com",
+      "frame-ancestors 'none'",
+    ].join("; ");
+
     return [
       {
         source: "/(.*)",
@@ -19,6 +31,11 @@ const nextConfig: NextConfig = {
             key: "Permissions-Policy",
             value: "camera=(), microphone=(), geolocation=()",
           },
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains; preload",
+          },
+          { key: "Content-Security-Policy", value: csp },
         ],
       },
     ];


### PR DESCRIPTION
## Summary
- Adds `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload` (2-year HSTS, eligible for preload list)
- Adds `Content-Security-Policy` restricting script/style/img/font/connect sources and setting `frame-ancestors 'none'`
- CSP allowlist includes Vercel Analytics (`va.vercel-scripts.com`) and Speed Insights (`vitals.vercel-insights.com`)
- `unsafe-inline` required for Next.js inline scripts (theme init) and Tailwind

## Test plan
- [x] Deploy to preview and check response headers with browser devtools
- [x] Verify Vercel Analytics and Speed Insights still load
- [x] Verify no CSP violations in browser console

closes #47, closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)