### PR TITLE
fix: escape < in JSON-LD to prevent </script> breakout XSS

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { Link } from "@/i18n/navigation";
 import { locales } from "@/i18n/config";
 import ReadingProgress from "@/components/ReadingProgress";
 import CodeBlock from "@/components/CodeBlock";
+import { safeJsonLd } from "@/lib/utils";
 
 interface PageProps {
   params: Promise<{ locale: string; slug: string }>;
@@ -106,7 +107,7 @@ export default async function BlogPostPage({ params }: PageProps) {
     <ReadingProgress />
     <script
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(blogPostingJsonLd) }}
+      dangerouslySetInnerHTML={{ __html: safeJsonLd(blogPostingJsonLd) }}
     />
     <div className="mx-auto max-w-3xl px-6 py-12">
       <Link

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -5,6 +5,7 @@ import Skills from "@/components/Skills";
 import Experience from "@/components/Experience";
 import Education from "@/components/Education";
 import { getAllPosts } from "@/lib/blog";
+import { safeJsonLd } from "@/lib/utils";
 
 interface PageProps {
   params: Promise<{ locale: string }>;
@@ -33,7 +34,7 @@ export default async function Home({ params }: PageProps) {
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: safeJsonLd(personJsonLd) }}
       />
       <Hero />
       <AtAGlance latestPost={latestPost} locale={locale} />

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { slugify } from "../utils";
+import { slugify, safeJsonLd } from "../utils";
 
 describe("slugify", () => {
   it("lowercases the string", () => {
@@ -49,5 +49,24 @@ describe("slugify", () => {
 
   it("returns empty string for all-punctuation input", () => {
     expect(slugify("!@#$%^&*()")).toBe("");
+  });
+});
+
+describe("safeJsonLd", () => {
+  it("serialises a plain object to JSON", () => {
+    const result = safeJsonLd({ "@type": "Person", name: "Pau" });
+    expect(JSON.parse(result)).toEqual({ "@type": "Person", name: "Pau" });
+  });
+
+  it("escapes < to prevent </script> breakout", () => {
+    const result = safeJsonLd({ title: "</script><script>alert(1)</script>" });
+    expect(result).not.toContain("</script>");
+    expect(result).toContain("\\u003c");
+  });
+
+  it("round-trips correctly after unescaping", () => {
+    const obj = { headline: "A <em>great</em> post" };
+    const escaped = safeJsonLd(obj);
+    expect(JSON.parse(escaped)).toEqual(obj);
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,12 @@
 /**
+ * Safely serialises an object for injection into a <script type="application/ld+json">.
+ * Escapes `<` as `\u003c` to prevent </script> breakout XSS.
+ */
+export function safeJsonLd(obj: unknown): string {
+  return JSON.stringify(obj).replace(/</g, "\\u003c");
+}
+
+/**
  * Converts a string to a URL-safe slug.
  * - Lowercases the string
  * - Strips diacritics (è→e, à→a, ç→c, etc.)


### PR DESCRIPTION
## Summary
- Adds `safeJsonLd(obj)` to `src/lib/utils.ts` — serialises to JSON then replaces `<` with `\u003c`, preventing `</script>` tag breakout when frontmatter data is injected into a `<script type="application/ld+json">` block
- Applied to `personJsonLd` on the home page and `blogPostingJsonLd` on blog post pages (where `post.title`/`post.description` come from MDX frontmatter)
- 3 new unit tests covering plain serialisation, XSS prevention, and round-trip correctness

## Test plan
- [ ] 154/154 tests pass
- [ ] JSON-LD still validates in Google's Rich Results Test

closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)