### PR TITLE
fix: replace useTranslations with getTranslations in server components

### DIFF
--- a/src/app/[locale]/blog/[slug]/not-found.tsx
+++ b/src/app/[locale]/blog/[slug]/not-found.tsx
@@ -1,8 +1,8 @@
-import { useTranslations } from "next-intl";
+import { getTranslations } from "next-intl/server";
 import { Link } from "@/i18n/navigation";
 
-export default function BlogPostNotFound() {
-  const t = useTranslations("blog");
+export default async function BlogPostNotFound() {
+  const t = await getTranslations("blog");
 
   return (
     <div className="mx-auto flex max-w-3xl flex-col items-center px-6 py-24 text-center">

--- a/src/components/Education.tsx
+++ b/src/components/Education.tsx
@@ -1,7 +1,7 @@
-import { useTranslations } from "next-intl";
+import { getTranslations } from "next-intl/server";
 
-export default function Education() {
-  const t = useTranslations("education");
+export default async function Education() {
+  const t = await getTranslations("education");
   const entries = t.raw("entries") as Array<{
     year: string;
     title: string;

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -1,7 +1,7 @@
-import { useTranslations } from "next-intl";
+import { getTranslations } from "next-intl/server";
 
-export default function Experience() {
-  const t = useTranslations("experience");
+export default async function Experience() {
+  const t = await getTranslations("experience");
   const jobs = t.raw("jobs") as Array<{
     period: string;
     role: string;


### PR DESCRIPTION
## Summary
Three server components were calling `useTranslations()` (the client React hook) without a `'use client'` directive. Hooks cannot be called in server components — this causes a runtime error when those pages render.

Converted all three to `async` server components using `getTranslations` from `next-intl/server`:
- `src/components/Education.tsx`
- `src/components/Experience.tsx`
- `src/app/[locale]/blog/[slug]/not-found.tsx`

## Test plan
- [ ] Home page renders Education and Experience sections correctly
- [ ] Navigating to a non-existent blog slug shows the 404 page with correct translated text
- [ ] TypeScript clean (`tsc --noEmit`)

closes #77, closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)