### PR TITLE
fix: strip surrounding quotes from .env.local values in scripts (#58)

### DIFF
--- a/scripts/new-post.ts
+++ b/scripts/new-post.ts
@@ -9,7 +9,11 @@ const envPath = path.join(process.cwd(), ".env.local");
 if (fs.existsSync(envPath)) {
   for (const line of fs.readFileSync(envPath, "utf-8").split("\n")) {
     const match = line.match(/^([^#=]+)=(.*)$/);
-    if (match) process.env[match[1].trim()] = match[2].trim();
+    if (match) {
+      // Strip surrounding single or double quotes (e.g. KEY="value" → value)
+      const value = match[2].trim().replace(/^(['"])(.*)\1$/, "$2");
+      process.env[match[1].trim()] = value;
+    }
   }
 }
 

--- a/scripts/translate-post.ts
+++ b/scripts/translate-post.ts
@@ -7,7 +7,11 @@ const envPath = path.join(process.cwd(), ".env.local");
 if (fs.existsSync(envPath)) {
   for (const line of fs.readFileSync(envPath, "utf-8").split("\n")) {
     const match = line.match(/^([^#=]+)=(.*)$/);
-    if (match) process.env[match[1].trim()] = match[2].trim();
+    if (match) {
+      // Strip surrounding single or double quotes (e.g. KEY="value" → value)
+      const value = match[2].trim().replace(/^(['"])(.*)\1$/, "$2");
+      process.env[match[1].trim()] = value;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- `new-post.ts` and `translate-post.ts` both use a manual `.env.local` parser
- The old regex stored `"sk-ant-..."` (with literal quotes) when the value was quoted — causing 401 from the Anthropic SDK
- Added a second `.replace(/^(['"])(.*)\1$/, "$2")` to strip surrounding quotes before assigning

## Test plan
- [ ] `ANTHROPIC_API_KEY="sk-ant-test"` in `.env.local` → script reads `sk-ant-test` (no quotes)
- [ ] `ANTHROPIC_API_KEY=sk-ant-test` (unquoted) → still works

Fixes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)