### PR TITLE
perf: add preconnect hints for Vercel Analytics and Speed Insights (#82)

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -115,6 +115,8 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
   return (
     <html lang={locale} suppressHydrationWarning>
       <head>
+        <link rel="preconnect" href="https://va.vercel-scripts.com" />
+        <link rel="preconnect" href="https://vitals.vercel-insights.com" />
         <script
           dangerouslySetInnerHTML={{
             __html: themeInitScript,


### PR DESCRIPTION
## Summary
- Adds `<link rel="preconnect">` for `va.vercel-scripts.com` and `vitals.vercel-insights.com` in the root layout `<head>`
- Lets the browser establish TCP+TLS handshakes in parallel with other page work, reducing first analytics beacon latency by ~100–300ms on cold connections
- Both origins are already in the CSP `connect-src` — no config changes needed

## Test plan
- [ ] View source on any page — confirm two preconnect `<link>` tags appear in `<head>`
- [ ] `pnpm build` passes

Fixes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)