### PR TITLE
feat: circular mask theme transition from button click origin

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -198,3 +198,34 @@ h1, h2, h3, h4 {
 /* Emphasis */
 .hljs-emphasis  { font-style: italic; }
 .hljs-strong    { font-weight: bold; }
+
+/* ─── Theme toggle — circular reveal (View Transitions API) ─────── */
+:root {
+  --expo-out: linear(
+    0 0%, 0.1684 2.66%, 0.3165 5.49%, 0.446 8.52%, 0.5581 11.78%,
+    0.6535 15.29%, 0.7341 19.11%, 0.8011 23.3%, 0.8557 27.93%,
+    0.8962 32.68%, 0.9283 38.01%, 0.9529 44.08%, 0.9711 51.14%,
+    0.9833 59.06%, 0.9915 68.74%, 1 100%
+  );
+}
+
+::view-transition-new(root) {
+  animation: theme-circle-reveal 0.7s var(--expo-out) both;
+}
+
+::view-transition-old(root) {
+  animation: none;
+  z-index: -1;
+}
+
+@keyframes theme-circle-reveal {
+  from { clip-path: circle(0% at var(--toggle-x, 50%) var(--toggle-y, 50%)); }
+  to   { clip-path: circle(150vmax at var(--toggle-x, 50%) var(--toggle-y, 50%)); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-new(root),
+  ::view-transition-old(root) {
+    animation: none !important;
+  }
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -7,10 +7,35 @@ export default function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
   const t = useTranslations("theme");
 
+  function handleClick(e: React.MouseEvent<HTMLButtonElement>) {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = Math.round(rect.left + rect.width / 2);
+    const y = Math.round(rect.top + rect.height / 2);
+
+    const root = document.documentElement;
+    root.style.setProperty("--toggle-x", `${x}px`);
+    root.style.setProperty("--toggle-y", `${y}px`);
+
+    const next = theme === "dark" ? "light" : "dark";
+
+    if (!("startViewTransition" in document)) {
+      toggleTheme();
+      return;
+    }
+
+    // Synchronously update data-theme inside the snapshot so the View
+    // Transition captures the correct before/after states.
+    (document as Document & { startViewTransition: (cb: () => void) => unknown })
+      .startViewTransition(() => {
+        root.setAttribute("data-theme", next);
+        toggleTheme(); // keeps React state in sync
+      });
+  }
+
   return (
     <button
       suppressHydrationWarning
-      onClick={toggleTheme}
+      onClick={handleClick}
       className="fixed bottom-6 right-6 z-50 rounded-md border border-border-color bg-bg-dark px-4 py-2 font-mono text-sm text-text-on-dark transition-colors hover:bg-bg-dark-secondary"
       aria-label={t("toggleLabel")}
     >


### PR DESCRIPTION
## Summary
Implements the circular reveal theme toggle effect from https://theme-toggle.rdsx.dev/

**How it works:**
1. On click, the button's center coordinates are captured and stored as `--toggle-x` / `--toggle-y` CSS custom properties on `:root`
2. The theme DOM update is wrapped in `document.startViewTransition()` — the `data-theme` attribute changes **synchronously inside the callback** so both before/after snapshots are captured correctly
3. `::view-transition-new(root)` animates `clip-path: circle(0%)` → `circle(150vmax)` centered at the click origin, with an expo-out easing curve
4. `::view-transition-old(root)` stays behind (`z-index: -1`) with no animation, getting covered by the expanding circle

**Key decisions:**
- `clip-path: circle(r at cx cy)` instead of SVG mask — simpler, same visual result
- Expo-out timing via `linear()` for a snappy, organic feel
- `startViewTransition` check + fallback for browsers without support (Safari < 18, Firefox without flag)
- `prefers-reduced-motion` disables the animation entirely

## Test plan
- [ ] Click the `[dark]` / `[light]` button — confirm circle expands from the button position
- [ ] Works in both directions (light→dark, dark→light)
- [ ] Instant fallback in Firefox (no flag) or older browsers
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)