### PR TITLE
fix(security): use ipAddress() for rate-limiter to prevent IP spoofing

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@vercel/analytics": "^1.6.1",
+    "@vercel/functions": "^3.4.4",
     "@vercel/speed-insights": "^2.0.0",
     "gray-matter": "^4.0.3",
     "next": "16.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@vercel/analytics':
         specifier: ^1.6.1
         version: 1.6.1(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+      '@vercel/functions':
+        specifier: ^3.4.4
+        version: 3.4.4
       '@vercel/speed-insights':
         specifier: ^2.0.0
         version: 2.0.0(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
@@ -1410,6 +1413,19 @@ packages:
         optional: true
       vue-router:
         optional: true
+
+  '@vercel/functions@3.4.4':
+    resolution: {integrity: sha512-mdmCTMxAUTT5GMSs/iS4EuovzoofXNbb44/iPFwlgqulnJg3FEf6Sk46kLlZL4zuTTJQPT5YPTdBgZVlYZ5Azg==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-web-identity': '*'
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-web-identity':
+        optional: true
+
+  '@vercel/oidc@3.2.1':
+    resolution: {integrity: sha512-UUqZ2y+VXHgVH1Luoo+477/NcrO4X+ln38U70ldRgGiWJAuHhtjTm7cCAnyLkl2feg7ZmTBK3F1kvJKFEQc01w==}
+    engines: {node: '>= 20'}
 
   '@vercel/speed-insights@2.0.0':
     resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
@@ -4513,6 +4529,12 @@ snapshots:
     optionalDependencies:
       next: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
+
+  '@vercel/functions@3.4.4':
+    dependencies:
+      '@vercel/oidc': 3.2.1
+
+  '@vercel/oidc@3.2.1': {}
 
   '@vercel/speed-insights@2.0.0(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     optionalDependencies:

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,3 +1,4 @@
+import { ipAddress } from "@vercel/functions";
 import { NextRequest, NextResponse } from "next/server";
 import { Resend } from "resend";
 
@@ -51,8 +52,12 @@ function isValidEmail(email: string): boolean {
 }
 
 export async function POST(req: NextRequest) {
+  // On Vercel, ipAddress() reads the verified edge IP and cannot be spoofed
+  // via crafted headers. Falls back to x-forwarded-for for local dev.
   const ip =
-    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+    ipAddress(req) ??
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    "unknown";
 
   if (isRateLimited(ip)) {
     return NextResponse.json(


### PR DESCRIPTION
## Summary

- Adds `@vercel/functions` dependency
- Replaces raw `x-forwarded-for` header extraction with `ipAddress(req)` from `@vercel/functions`
- Falls back to `x-forwarded-for` then `"unknown"` for non-Vercel environments (local dev)

Previously an attacker could send a different `x-forwarded-for` value on every request, making the rate limiter ineffective. `ipAddress()` reads the verified IP set by Vercel's edge infrastructure, which cannot be spoofed via headers.

## Test plan
- [x] All 165 unit tests pass
- [x] `next build` completes with 0 errors

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)