### PR TITLE
fix(a11y): promote blog post headings from h3 to h2 (WCAG 2.4.6)

### DIFF
--- a/content/blog/ca/pla-i-primera-versio.mdx
+++ b/content/blog/ca/pla-i-primera-versio.mdx
@@ -8,15 +8,15 @@ published: true
 
 Tots els canvis d'etapa porten noves oportunitats. Fa poc em vaig quedar sense feina i, lluny de veure-ho com una aturada, vaig decidir que era el moment perfecte per prémer l'accelerador. El mercat tecnològic es mou a una velocitat vertiginosa, especialment amb tot el que envolta la Intel·ligència Artificial, i volia aprofitar aquest parèntesi per posar-me al dia de veritat.
 
-### L'espurna del projecte
+## L'espurna del projecte
 
 La idea no va sortir del buit. Va ser arran d'una conversa amb companys del sector que les peces van començar a encaixar. Parlant sobre cap a on va el desenvolupament de programari i com les eines d'IA estan canviant el nostre *workflow*, vaig tenir clar per on volia començar. Aquella xerrada va ser el motor que em faltava per engrescar-me i passar de la teoria a la pràctica.
 
-### L'eina i la planificació (sense por a la quota)
+## L'eina i la planificació (sense por a la quota)
 
 Per a aquest projecte, he triat **Claude Code** com a eina principal. Volia provar els seus límits i la veritat és que m'hi vaig llançar de ple: vaig esgotar pràcticament tota la quota de la subscripció només en la fase de planificació. Pot semblar exagerat, però tenir un full de ruta sòlid abans de picar la primera línia de codi ha estat clau per entendre les capacitats de l'eina.
 
-### Primeres passes: La meva carta de presentació
+## Primeres passes: La meva carta de presentació
 
 El "Dia 1" tenia un objectiu clar: construir la meva infraestructura base. He creat una pàgina personal que serveix de currículum viu, utilitzant el següent stack:
 
@@ -26,7 +26,7 @@ El "Dia 1" tenia un objectiu clar: construir la meva infraestructura base. He cr
 
 És el primer lliurable tangible, una base sòlida sobre la qual anar construint coses més complexes.
 
-### El que vindrà
+## El que vindrà
 
 Això només és el principi. El pla no es queda en una web estàtica; ja estic dissenyant un **sistema automatitzat de millores i gestió de Issues a GitHub**. La idea és utilitzar la IA no només per escriure codi, sinó per gestionar el cicle de vida del projecte de manera autònoma.
 

--- a/content/blog/en/pla-i-primera-versio.mdx
+++ b/content/blog/en/pla-i-primera-versio.mdx
@@ -8,15 +8,15 @@ published: true
 
 Every change of stage brings new opportunities. I recently lost my job and, far from seeing it as a setback, I decided it was the perfect moment to hit the accelerator. The tech market moves at a dizzying speed, especially with everything surrounding Artificial Intelligence, and I wanted to take advantage of this pause to truly get up to speed.
 
-### The spark of the project
+## The spark of the project
 
 The idea didn't come out of nowhere. It was during a conversation with colleagues in the industry that the pieces started to fall into place. Talking about where software development is heading and how AI tools are changing our *workflow*, I knew exactly where I wanted to start. That conversation was the driving force I needed to get excited and go from theory to practice.
 
-### The tool and the planning (without fearing the quota)
+## The tool and the planning (without fearing the quota)
 
 For this project, I chose **Claude Code** as my main tool. I wanted to test its limits and the truth is I dove in headfirst: I used up practically the entire subscription quota just in the planning phase. It might seem excessive, but having a solid roadmap before writing the first line of code was key to understanding the tool's capabilities.
 
-### First steps: My cover letter
+## First steps: My cover letter
 
 "Day 1" had a clear objective: build my base infrastructure. I created a personal page that serves as a living résumé, using the following stack:
 
@@ -26,7 +26,7 @@ For this project, I chose **Claude Code** as my main tool. I wanted to test its 
 
 It's the first tangible deliverable, a solid foundation on which to build more complex things.
 
-### What's coming next
+## What's coming next
 
 This is only the beginning. The plan doesn't stop at a static website; I'm already designing an **automated system for improvements and GitHub Issue management**. The idea is to use AI not only to write code, but to manage the project lifecycle autonomously.
 

--- a/content/blog/es/pla-i-primera-versio.mdx
+++ b/content/blog/es/pla-i-primera-versio.mdx
@@ -8,15 +8,15 @@ published: true
 
 Todos los cambios de etapa traen nuevas oportunidades. Hace poco me quedé sin trabajo y, lejos de verlo como un parón, decidí que era el momento perfecto para pisar el acelerador. El mercado tecnológico se mueve a una velocidad vertiginosa, especialmente con todo lo que rodea a la Inteligencia Artificial, y quería aprovechar este paréntesis para ponerme al día de verdad.
 
-### La chispa del proyecto
+## La chispa del proyecto
 
 La idea no surgió de la nada. Fue a raíz de una conversación con compañeros del sector que las piezas empezaron a encajar. Hablando sobre hacia dónde va el desarrollo de software y cómo las herramientas de IA están cambiando nuestro *workflow*, tuve claro por dónde quería empezar. Aquella charla fue el motor que me faltaba para entusiasmarme y pasar de la teoría a la práctica.
 
-### La herramienta y la planificación (sin miedo a la cuota)
+## La herramienta y la planificación (sin miedo a la cuota)
 
 Para este proyecto, he elegido **Claude Code** como herramienta principal. Quería probar sus límites y la verdad es que me lancé de lleno: agoté prácticamente toda la cuota de la suscripción solo en la fase de planificación. Puede parecer exagerado, pero tener una hoja de ruta sólida antes de escribir la primera línea de código ha sido clave para entender las capacidades de la herramienta.
 
-### Primeros pasos: Mi carta de presentación
+## Primeros pasos: Mi carta de presentación
 
 El "Día 1" tenía un objetivo claro: construir mi infraestructura base. He creado una página personal que sirve de currículum vivo, utilizando el siguiente stack:
 
@@ -26,7 +26,7 @@ El "Día 1" tenía un objetivo claro: construir mi infraestructura base. He crea
 
 Es el primer entregable tangible, una base sólida sobre la que ir construyendo cosas más complejas.
 
-### Lo que vendrá
+## Lo que vendrá
 
 Esto solo es el principio. El plan no se queda en una web estática; ya estoy diseñando un **sistema automatizado de mejoras y gestión de Issues en GitHub**. La idea es utilizar la IA no solo para escribir código, sino para gestionar el ciclo de vida del proyecto de manera autónoma.
 

--- a/scripts/new-post.ts
+++ b/scripts/new-post.ts
@@ -94,6 +94,10 @@ published: true
 ---
 
 Escriu el teu contingut aquí...
+
+## Primera secció
+
+Contingut de la secció...
 `;
 
   const dir = blogDir("ca");


### PR DESCRIPTION
## Summary

- Changes all section headings in `pla-i-primera-versio.mdx` (ca/en/es) from `###` (h3) to `##` (h2)
- Fixes an h1 → h3 heading gap that violates WCAG 2.4.6 and breaks screen reader heading navigation
- Updates `scripts/new-post.ts` template to scaffold new posts with an `##` example, preventing the issue in future content

## Test plan
- [x] All 165 unit tests pass
- [x] `grep "^###" content/blog/**/*.mdx` returns no results

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)