### PR TITLE
fix(a11y): i18n ReadingProgress aria-label

### DIFF
--- a/src/components/ReadingProgress.tsx
+++ b/src/components/ReadingProgress.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 
 export default function ReadingProgress() {
+  const t = useTranslations("blog");
   const [progress, setProgress] = useState(0);
 
   useEffect(() => {
@@ -29,7 +31,7 @@ export default function ReadingProgress() {
       aria-valuenow={Math.round(progress)}
       aria-valuemin={0}
       aria-valuemax={100}
-      aria-label="Reading progress"
+      aria-label={t("readingProgress")}
       style={{
         position: "fixed",
         top: 0,

--- a/src/components/__tests__/ReadingProgress.test.tsx
+++ b/src/components/__tests__/ReadingProgress.test.tsx
@@ -2,8 +2,19 @@
  * @vitest-environment happy-dom
  */
 import { render, screen, act } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import ReadingProgress from "@/components/ReadingProgress";
+
+const messages = { blog: { readingProgress: "Reading progress" } };
+
+function renderWithIntl(ui: React.ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
 
 function setScrollState({
   scrollY,
@@ -36,21 +47,21 @@ describe("ReadingProgress", () => {
   });
 
   it("renders a progressbar element", () => {
-    render(<ReadingProgress />);
+    renderWithIntl(<ReadingProgress />);
     expect(screen.getByRole("progressbar")).toBeTruthy();
   });
 
   it("has correct aria attributes", () => {
-    render(<ReadingProgress />);
+    renderWithIntl(<ReadingProgress />);
     const bar = screen.getByRole("progressbar");
     expect(bar).toHaveAttribute("aria-valuemin", "0");
     expect(bar).toHaveAttribute("aria-valuemax", "100");
-    expect(bar).toHaveAttribute("aria-label", "Reading progress");
+    expect(bar).toHaveAttribute("aria-label", messages.blog.readingProgress);
   });
 
   it("starts at 0% progress when at top of page", () => {
     setScrollState({ scrollY: 0, scrollHeight: 1000, innerHeight: 500 });
-    render(<ReadingProgress />);
+    renderWithIntl(<ReadingProgress />);
     const bar = screen.getByRole("progressbar");
     expect(bar).toHaveAttribute("aria-valuenow", "0");
     expect(bar.style.width).toBe("0%");
@@ -58,28 +69,28 @@ describe("ReadingProgress", () => {
 
   it("shows 50% progress when scrolled halfway", () => {
     setScrollState({ scrollY: 250, scrollHeight: 1000, innerHeight: 500 });
-    render(<ReadingProgress />);
+    renderWithIntl(<ReadingProgress />);
     const bar = screen.getByRole("progressbar");
     expect(bar).toHaveAttribute("aria-valuenow", "50");
   });
 
   it("shows 100% progress when scrolled to bottom", () => {
     setScrollState({ scrollY: 500, scrollHeight: 1000, innerHeight: 500 });
-    render(<ReadingProgress />);
+    renderWithIntl(<ReadingProgress />);
     const bar = screen.getByRole("progressbar");
     expect(bar).toHaveAttribute("aria-valuenow", "100");
   });
 
   it("clamps progress to 100% if scrollY exceeds docHeight", () => {
     setScrollState({ scrollY: 600, scrollHeight: 1000, innerHeight: 500 });
-    render(<ReadingProgress />);
+    renderWithIntl(<ReadingProgress />);
     const bar = screen.getByRole("progressbar");
     expect(bar).toHaveAttribute("aria-valuenow", "100");
   });
 
   it("updates progress on scroll event", () => {
     setScrollState({ scrollY: 0, scrollHeight: 1000, innerHeight: 500 });
-    render(<ReadingProgress />);
+    renderWithIntl(<ReadingProgress />);
     const bar = screen.getByRole("progressbar");
     expect(bar).toHaveAttribute("aria-valuenow", "0");
 
@@ -93,7 +104,7 @@ describe("ReadingProgress", () => {
 
   it("updates progress on resize event", () => {
     setScrollState({ scrollY: 250, scrollHeight: 1000, innerHeight: 500 });
-    render(<ReadingProgress />);
+    renderWithIntl(<ReadingProgress />);
 
     act(() => {
       Object.defineProperty(window, "innerHeight", {
@@ -110,20 +121,20 @@ describe("ReadingProgress", () => {
 
   it("handles case when document is shorter than viewport", () => {
     setScrollState({ scrollY: 0, scrollHeight: 400, innerHeight: 500 });
-    render(<ReadingProgress />);
+    renderWithIntl(<ReadingProgress />);
     const bar = screen.getByRole("progressbar");
     expect(bar).toHaveAttribute("aria-valuenow", "0");
     expect(bar.style.width).toBe("0%");
   });
 
   it("uses CSS variable for background color", () => {
-    render(<ReadingProgress />);
+    renderWithIntl(<ReadingProgress />);
     const bar = screen.getByRole("progressbar");
     expect(bar.style.backgroundColor).toBe("var(--text-accent)");
   });
 
   it("has fixed positioning at top of viewport", () => {
-    render(<ReadingProgress />);
+    renderWithIntl(<ReadingProgress />);
     const bar = screen.getByRole("progressbar");
     expect(bar.style.position).toBe("fixed");
     expect(bar.style.top).toBe("0px");

--- a/src/i18n/messages/ca.json
+++ b/src/i18n/messages/ca.json
@@ -297,7 +297,8 @@
     "notFoundMessage": "L'article que cerques no existeix o ha estat eliminat.",
     "notFoundBack": "← Tornar al blog",
     "translationWarning": "Aquest article va ser escrit originalment en català. Estàs llegint una traducció automàtica.",
-    "readOriginal": "Llegir l'original en català"
+    "readOriginal": "Llegir l'original en català",
+    "readingProgress": "Progrés de lectura"
   },
   "contact": {
     "heading": "Contacte",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -297,7 +297,8 @@
     "notFoundMessage": "The post you're looking for doesn't exist or has been removed.",
     "notFoundBack": "← Back to blog",
     "translationWarning": "This article was originally written in Catalan. You are reading an automatic translation.",
-    "readOriginal": "Read the original in Catalan"
+    "readOriginal": "Read the original in Catalan",
+    "readingProgress": "Reading progress"
   },
   "contact": {
     "heading": "Contact",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -297,7 +297,8 @@
     "notFoundMessage": "El artículo que buscas no existe o ha sido eliminado.",
     "notFoundBack": "← Volver al blog",
     "translationWarning": "Este artículo fue escrito originalmente en catalán. Estás leyendo una traducción automática.",
-    "readOriginal": "Leer el original en catalán"
+    "readOriginal": "Leer el original en catalán",
+    "readingProgress": "Progreso de lectura"
   },
   "contact": {
     "heading": "Contacto",


### PR DESCRIPTION
## Summary

- Replaces hardcoded `aria-label="Reading progress"` with `t("readingProgress")` via `useTranslations("blog")`
- Adds `readingProgress` key to ca/es/en locale message files
- Updates test suite to wrap renders in `NextIntlClientProvider` and use the messages constant for assertions

Without this fix, screen reader users on Catalan or Spanish locales heard an English accessible name, contradicting the multilingual setup.

## Test plan
- [x] All 165 unit tests pass (incl. updated ReadingProgress tests)
- [x] `next build` completes with 0 errors

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)