### PR TITLE
feat: add robots.txt and sitemap.xml (Next.js App Router)

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://paubartrina.cat";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/"],
+      },
+    ],
+    sitemap: `${BASE_URL}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,50 @@
+import type { MetadataRoute } from "next";
+import { getAllPosts } from "@/lib/blog";
+import { locales } from "@/i18n/config";
+
+const BASE_URL = "https://paubartrina.cat";
+
+type Locale = (typeof locales)[number];
+
+const staticRoutes = ["", "/blog", "/contacte", "/uses", "/ara"] as const;
+
+function alternates(path: string): Record<string, string> {
+  return Object.fromEntries(locales.map((locale) => [locale, `${BASE_URL}/${locale}${path}`]));
+}
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const entries: MetadataRoute.Sitemap = [];
+
+  // Static routes
+  for (const locale of locales as readonly Locale[]) {
+    for (const route of staticRoutes) {
+      entries.push({
+        url: `${BASE_URL}/${locale}${route}`,
+        lastModified: new Date(),
+        changeFrequency: route === "" ? "weekly" : "monthly",
+        priority: route === "" ? 1.0 : 0.8,
+        alternates: {
+          languages: alternates(route),
+        },
+      });
+    }
+  }
+
+  // Blog posts
+  for (const locale of locales as readonly Locale[]) {
+    const posts = getAllPosts(locale);
+    for (const post of posts) {
+      entries.push({
+        url: `${BASE_URL}/${locale}/blog/${post.slug}`,
+        lastModified: post.date ? new Date(post.date) : new Date(),
+        changeFrequency: "monthly",
+        priority: 0.6,
+        alternates: {
+          languages: alternates(`/blog/${post.slug}`),
+        },
+      });
+    }
+  }
+
+  return entries;
+}


### PR DESCRIPTION
## Summary

- **`src/app/robots.ts`** — generates `/robots.txt` allowing all crawlers on `/`, blocking `/api/`, and pointing to the sitemap
- **`src/app/sitemap.ts`** — generates `/sitemap.xml` with:
  - All static routes per locale (`/`, `/blog`, `/contacte`, `/uses`, `/ara`) with hreflang alternates
  - All blog posts per locale with per-post `lastModified` dates
  - Priority hints (1.0 home, 0.8 static pages, 0.6 posts) and change frequency hints

Closes #143
Closes #60

## Test plan

- [x] `vitest run` — 165 tests pass
- [x] `pnpm build` — build output shows `/robots.txt` and `/sitemap.xml` as static pages
- [x] Verified `/api/` is disallowed in robots rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)