### PR TITLE
feat(blog): prev/next navigation, post count + word count

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -5,10 +5,11 @@ import { compileMDX } from "next-mdx-remote/rsc";
 import rehypeHighlight from "rehype-highlight";
 import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
-import { getAllSlugs, getPostBySlug, getAvailableLocales } from "@/lib/blog";
+import { getAllSlugs, getPostBySlug, getAvailableLocales, getAdjacentPosts } from "@/lib/blog";
 import { Link } from "@/i18n/navigation";
 import { locales } from "@/i18n/config";
 import ReadingProgress from "@/components/ReadingProgress";
+import PostNavigation from "@/components/PostNavigation";
 import CodeBlock from "@/components/CodeBlock";
 import { safeJsonLd } from "@/lib/utils";
 
@@ -75,6 +76,7 @@ export default async function BlogPostPage({ params }: PageProps) {
   if (!post) notFound();
 
   const t = await getTranslations({ locale, namespace: "blog" });
+  const { prev, next } = getAdjacentPosts(locale, slug);
 
   const blogPostingJsonLd = {
     "@context": "https://schema.org",
@@ -139,7 +141,8 @@ export default async function BlogPostPage({ params }: PageProps) {
         </h1>
         <div className="flex flex-wrap gap-3 font-mono text-sm text-text-secondary">
           <time>{post.date}</time>
-          <span>{post.readingTime}</span>
+          <span>{t("readingTime", { count: post.readingTimeMinutes })}</span>
+          <span>{t("wordCount", { count: post.wordCount })}</span>
         </div>
         {post.tags.length > 0 && (
           <div className="mt-4 flex flex-wrap gap-2">
@@ -158,6 +161,8 @@ export default async function BlogPostPage({ params }: PageProps) {
       <article className="prose prose-lg max-w-none">
         {content}
       </article>
+
+      <PostNavigation prev={prev} next={next} locale={locale} />
     </div>
     </>
   );

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -64,9 +64,16 @@ export default async function BlogPage({ params, searchParams }: PageProps) {
 
   return (
     <div className="mx-auto max-w-3xl px-6 py-12">
-      <h1 className="mb-8 font-mono text-4xl font-bold text-text-primary">
-        {t("heading")}
-      </h1>
+      <div className="mb-8 flex flex-wrap items-baseline gap-4">
+        <h1 className="font-mono text-4xl font-bold text-text-primary">
+          {t("heading")}
+        </h1>
+        {posts.length > 0 && (
+          <span className="font-mono text-sm text-text-secondary">
+            {t("postCount", { count: posts.length })}
+          </span>
+        )}
+      </div>
 
       {posts.length === 0 ? (
         <p className="font-mono text-text-secondary">{t("emptyState")}</p>

--- a/src/components/BlogCard.tsx
+++ b/src/components/BlogCard.tsx
@@ -1,7 +1,10 @@
+import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
 import type { BlogPostMeta } from "@/lib/blog";
 
 export default function BlogCard({ post }: { post: BlogPostMeta }) {
+  const t = useTranslations("blog");
+
   return (
     <article className="relative rounded-lg border border-card-border bg-card-bg p-6 transition-shadow hover:shadow-lg">
       <Link
@@ -14,7 +17,7 @@ export default function BlogCard({ post }: { post: BlogPostMeta }) {
       </h2>
       <div className="mb-3 flex flex-wrap gap-3 font-mono text-xs text-text-secondary">
         <time>{post.date}</time>
-        <span>{post.readingTime}</span>
+        <span>{t("readingTime", { count: post.readingTimeMinutes })}</span>
       </div>
       <p className="mb-4 font-mono text-sm text-text-secondary">
         {post.description}

--- a/src/components/PostNavigation.tsx
+++ b/src/components/PostNavigation.tsx
@@ -1,0 +1,54 @@
+import { getTranslations } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
+import type { BlogPostMeta } from "@/lib/blog";
+
+interface PostNavigationProps {
+  prev: BlogPostMeta | null;
+  next: BlogPostMeta | null;
+  locale: string;
+}
+
+export default async function PostNavigation({
+  prev,
+  next,
+  locale,
+}: PostNavigationProps) {
+  const t = await getTranslations({ locale, namespace: "blog" });
+
+  if (!prev && !next) return null;
+
+  return (
+    <nav
+      aria-label="Post navigation"
+      className="mt-12 flex items-start justify-between gap-4 border-t border-border-color pt-8 font-mono text-sm"
+    >
+      <div className="flex-1">
+        {prev && (
+          <Link
+            href={`/blog/${prev.slug}`}
+            className="group flex flex-col gap-1 text-text-secondary hover:text-text-accent"
+          >
+            <span className="text-xs text-text-accent">{t("prevPost")}</span>
+            <span className="line-clamp-2 transition-colors group-hover:text-text-accent">
+              {prev.title}
+            </span>
+          </Link>
+        )}
+      </div>
+
+      <div className="flex-1 text-right">
+        {next && (
+          <Link
+            href={`/blog/${next.slug}`}
+            className="group flex flex-col gap-1 text-text-secondary hover:text-text-accent"
+          >
+            <span className="text-xs text-text-accent">{t("nextPost")}</span>
+            <span className="line-clamp-2 transition-colors group-hover:text-text-accent">
+              {next.title}
+            </span>
+          </Link>
+        )}
+      </div>
+    </nav>
+  );
+}

--- a/src/components/__tests__/BlogList.test.tsx
+++ b/src/components/__tests__/BlogList.test.tsx
@@ -43,7 +43,8 @@ const makePosts = (): BlogPostMeta[] => [
     date: "2026-01-01",
     description: "Desc A",
     tags: ["react", "typescript"],
-    readingTime: "2 min",
+    readingTime: "2 min read",
+    readingTimeMinutes: 2,
     locale: "en",
   },
   {
@@ -52,7 +53,8 @@ const makePosts = (): BlogPostMeta[] => [
     date: "2026-01-02",
     description: "Desc B",
     tags: ["react"],
-    readingTime: "3 min",
+    readingTime: "3 min read",
+    readingTimeMinutes: 3,
     locale: "en",
   },
   {
@@ -61,7 +63,8 @@ const makePosts = (): BlogPostMeta[] => [
     date: "2026-01-03",
     description: "Desc C",
     tags: ["typescript"],
-    readingTime: "4 min",
+    readingTime: "4 min read",
+    readingTimeMinutes: 4,
     locale: "en",
   },
 ];

--- a/src/i18n/messages/ca.json
+++ b/src/i18n/messages/ca.json
@@ -291,14 +291,18 @@
     "description": "Articles sobre desenvolupament web i tecnologia",
     "emptyState": "Encara no hi ha articles. Torna aviat!",
     "allTags": "Tots",
-    "readingTime": "min de lectura",
+    "readingTime": "{count} min de lectura",
     "backToList": "← Tornar al blog",
     "notFoundTitle": "Article no trobat",
     "notFoundMessage": "L'article que cerques no existeix o ha estat eliminat.",
     "notFoundBack": "← Tornar al blog",
     "translationWarning": "Aquest article va ser escrit originalment en català. Estàs llegint una traducció automàtica.",
     "readOriginal": "Llegir l'original en català",
-    "readingProgress": "Progrés de lectura"
+    "readingProgress": "Progrés de lectura",
+    "postCount": "{count, plural, one {# article} other {# articles}}",
+    "wordCount": "{count} paraules",
+    "prevPost": "← Anterior",
+    "nextPost": "Següent →"
   },
   "contact": {
     "heading": "Contacte",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -291,14 +291,18 @@
     "description": "Articles about web development and technology",
     "emptyState": "No articles yet. Come back soon!",
     "allTags": "All",
-    "readingTime": "min read",
+    "readingTime": "{count} min read",
     "backToList": "← Back to blog",
     "notFoundTitle": "Post not found",
     "notFoundMessage": "The post you're looking for doesn't exist or has been removed.",
     "notFoundBack": "← Back to blog",
     "translationWarning": "This article was originally written in Catalan. You are reading an automatic translation.",
     "readOriginal": "Read the original in Catalan",
-    "readingProgress": "Reading progress"
+    "readingProgress": "Reading progress",
+    "postCount": "{count, plural, one {# post} other {# posts}}",
+    "wordCount": "{count} words",
+    "prevPost": "← Previous",
+    "nextPost": "Next →"
   },
   "contact": {
     "heading": "Contact",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -291,14 +291,18 @@
     "description": "Artículos sobre desarrollo web y tecnología",
     "emptyState": "Todavía no hay artículos. ¡Vuelve pronto!",
     "allTags": "Todos",
-    "readingTime": "min de lectura",
+    "readingTime": "{count} min de lectura",
     "backToList": "← Volver al blog",
     "notFoundTitle": "Artículo no encontrado",
     "notFoundMessage": "El artículo que buscas no existe o ha sido eliminado.",
     "notFoundBack": "← Volver al blog",
     "translationWarning": "Este artículo fue escrito originalmente en catalán. Estás leyendo una traducción automática.",
     "readOriginal": "Leer el original en catalán",
-    "readingProgress": "Progreso de lectura"
+    "readingProgress": "Progreso de lectura",
+    "postCount": "{count, plural, one {# artículo} other {# artículos}}",
+    "wordCount": "{count} palabras",
+    "prevPost": "← Anterior",
+    "nextPost": "Siguiente →"
   },
   "contact": {
     "heading": "Contacto",

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -15,6 +15,8 @@ export interface BlogPost {
   tags: string[];
   published: boolean;
   readingTime: string;
+  readingTimeMinutes: number;
+  wordCount: number;
   content: string;
 }
 
@@ -26,6 +28,12 @@ export interface BlogPostMeta {
   description: string;
   tags: string[];
   readingTime: string;
+  readingTimeMinutes: number;
+}
+
+export interface AdjacentPosts {
+  prev: BlogPostMeta | null;
+  next: BlogPostMeta | null;
 }
 
 export function getAllPosts(locale: string): BlogPostMeta[] {
@@ -44,6 +52,7 @@ export function getAllPosts(locale: string): BlogPostMeta[] {
         return null;
       }
 
+      const rt = readingTime(content);
       return {
         slug,
         locale,
@@ -51,7 +60,8 @@ export function getAllPosts(locale: string): BlogPostMeta[] {
         date: data.date || "",
         description: data.description || "",
         tags: data.tags || [],
-        readingTime: readingTime(content).text,
+        readingTime: rt.text,
+        readingTimeMinutes: Math.ceil(rt.minutes),
       };
     })
     .filter(Boolean) as BlogPostMeta[];
@@ -72,6 +82,7 @@ export function getPostBySlug(
   const raw = fs.readFileSync(filePath, "utf-8");
   const { data, content } = matter(raw);
 
+  const rt = readingTime(content);
   return {
     slug,
     title: data.title || slug,
@@ -79,8 +90,26 @@ export function getPostBySlug(
     description: data.description || "",
     tags: data.tags || [],
     published: data.published !== false,
-    readingTime: readingTime(content).text,
+    readingTime: rt.text,
+    readingTimeMinutes: Math.ceil(rt.minutes),
+    wordCount: rt.words,
     content,
+  };
+}
+
+export function getAdjacentPosts(
+  locale: string,
+  slug: string
+): AdjacentPosts {
+  const posts = getAllPosts(locale);
+  const index = posts.findIndex((p) => p.slug === slug);
+  if (index === -1) return { prev: null, next: null };
+
+  return {
+    // "next" post = published after current (lower index, since sorted desc)
+    next: index > 0 ? posts[index - 1] : null,
+    // "prev" post = published before current (higher index)
+    prev: index < posts.length - 1 ? posts[index + 1] : null,
   };
 }
 


### PR DESCRIPTION
## Summary

Three blog improvements in one branch:

- **#81 Prev/next post navigation** — `PostNavigation` component renders at the bottom of every post with links to the previous (older) and next (newer) post
- **#59 Post count on listing** — post count shown inline next to the Blog heading (e.g. "1 article")
- **#115 Word count in post header** — word count displayed in the post header metadata row alongside the reading time
- **Bonus**: reading time is now fully localized via i18n templates (`{count} min read` / `{count} min de lectura`) instead of the hardcoded English string from the `reading-time` package

Closes #81
Closes #59
Closes #115

## Test plan

- [x] Updated `BlogList.test.tsx` fixtures to include `readingTimeMinutes`
- [x] `vitest run` — 165 tests pass, 0 failures
- [x] `pnpm build` — build succeeds, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)