### PR TITLE
feat: scroll-to-top button + copy email on contact page

### DIFF
--- a/src/app/[locale]/contacte/page.tsx
+++ b/src/app/[locale]/contacte/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { locales } from "@/i18n/config";
 import ContactForm from "./ContactForm";
+import CopyEmail from "@/components/CopyEmail";
 
 const BASE_URL = "https://paubartrina.cat";
 const OG_IMAGE = `${BASE_URL}/og-default.png`;
@@ -65,6 +66,7 @@ export default async function ContactePage({ params }: PageProps) {
           </p>
 
           <ContactForm />
+          <CopyEmail />
         </div>
       </div>
     </section>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from "@/lib/theme";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import ThemeToggle from "@/components/ThemeToggle";
+import ScrollToTop from "@/components/ScrollToTop";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { routing } from "@/i18n/routing";
@@ -140,6 +141,7 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
             </main>
             <Footer />
             <ThemeToggle />
+            <ScrollToTop />
           </ThemeProvider>
         </NextIntlClientProvider>
         <Analytics />

--- a/src/components/CopyEmail.tsx
+++ b/src/components/CopyEmail.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+
+const EMAIL = "paumc.bcn@gmail.com";
+
+export default function CopyEmail() {
+  const [copied, setCopied] = useState(false);
+  const t = useTranslations("common");
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(EMAIL);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API not available — fallback: open mailto
+      window.location.href = `mailto:${EMAIL}`;
+    }
+  };
+
+  return (
+    <div className="mt-6 flex flex-col items-center gap-2 font-mono text-sm text-text-secondary">
+      <span>{t("orEmail")}</span>
+      <div className="flex items-center gap-2">
+        <a
+          href={`mailto:${EMAIL}`}
+          className="text-text-accent hover:underline"
+        >
+          {EMAIL}
+        </a>
+        <button
+          onClick={handleCopy}
+          aria-label={copied ? t("emailCopied") : t("copyEmail")}
+          className="rounded-md border border-border-color px-2 py-1 text-xs transition-colors hover:border-text-accent hover:text-text-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-text-accent"
+        >
+          {copied ? t("emailCopied") : t("copyEmail")}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+
+export default function ScrollToTop() {
+  const [visible, setVisible] = useState(false);
+  const t = useTranslations("common");
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 400);
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  if (!visible) return null;
+
+  return (
+    <button
+      onClick={scrollToTop}
+      aria-label={t("scrollToTop")}
+      className="fixed bottom-20 right-6 z-50 flex h-10 w-10 items-center justify-center rounded-full border border-border-color bg-card-bg font-mono text-lg text-text-accent shadow-md transition-all hover:scale-110 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-text-accent md:bottom-6"
+    >
+      ↑
+    </button>
+  );
+}

--- a/src/i18n/messages/ca.json
+++ b/src/i18n/messages/ca.json
@@ -411,5 +411,11 @@
   "codeBlock": {
     "copy": "Copia",
     "copied": "Copiat!"
+  },
+  "common": {
+    "scrollToTop": "Tornar amunt",
+    "copyEmail": "Copia el correu",
+    "emailCopied": "Copiat!",
+    "orEmail": "o escriu-me directament"
   }
 }

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -411,5 +411,11 @@
   "codeBlock": {
     "copy": "Copy",
     "copied": "Copied!"
+  },
+  "common": {
+    "scrollToTop": "Back to top",
+    "copyEmail": "Copy email",
+    "emailCopied": "Copied!",
+    "orEmail": "or email me directly"
   }
 }

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -411,5 +411,11 @@
   "codeBlock": {
     "copy": "Copiar",
     "copied": "¡Copiado!"
+  },
+  "common": {
+    "scrollToTop": "Volver arriba",
+    "copyEmail": "Copiar correo",
+    "emailCopied": "¡Copiado!",
+    "orEmail": "o escríbeme directamente"
   }
 }


### PR DESCRIPTION
## Summary

- **#102 Scroll-to-top button** — `ScrollToTop` component: fixed-position button that appears after 400px of scroll, smooth-scrolls to top on click. Positioned bottom-right, above the ThemeToggle on mobile. Accessible `aria-label` from i18n.
- **#138 Copy email / mailto fallback** — `CopyEmail` component below the contact form: shows the email address as a `mailto:` link plus a one-click clipboard copy button. If the Clipboard API is unavailable (e.g. no HTTPS in local dev), it falls back to opening `mailto:` directly.
- New `common` i18n namespace added to all three locales (ca/es/en).

Closes #102
Closes #138

## Test plan

- [x] `vitest run` — 165 tests pass, 0 failures
- [x] `pnpm build` — production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)