### PR TITLE
feat: git-based last-updated dates on /now page and footer

### DIFF
--- a/src/app/[locale]/ara/page.tsx
+++ b/src/app/[locale]/ara/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { locales } from "@/i18n/config";
+import { getLastCommitDate, formatCommitDate } from "@/lib/git";
 
 interface PageProps {
   params: Promise<{ locale: string }>;
@@ -65,14 +66,22 @@ export default async function AraPage({ params }: PageProps) {
   const priorityCount = (t.raw("priorities") as string[]).length;
   const excitementCount = (t.raw("excitement") as string[]).length;
 
+  const rawDate = getLastCommitDate([
+    "src/i18n/messages/ca.json",
+    "src/app/[locale]/ara/page.tsx",
+  ]);
+  const lastUpdated = rawDate ? formatCommitDate(rawDate, locale) : null;
+
   return (
     <div className="mx-auto max-w-3xl px-6 py-12">
       <h1 className="mb-2 font-mono text-4xl font-bold text-text-primary">
         {t("heading")}
       </h1>
-      <p className="mb-8 font-mono text-sm text-text-secondary">
-        {t("lastUpdated")}
-      </p>
+      {lastUpdated && (
+        <p className="mb-8 font-mono text-sm text-text-secondary">
+          {t("lastUpdated", { date: lastUpdated })}
+        </p>
+      )}
 
       <div className="space-y-8 font-mono text-text-primary">
         <p>{t.rich("location", richComponents)}</p>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 import { getTranslations, getLocale } from "next-intl/server";
 import { Link } from "@/i18n/navigation";
+import { getLastCommitDate, formatCommitDate } from "@/lib/git";
 
 const socialLinks = [
   { href: "https://bsky.app/profile/paubartrina.cat", label: "Bluesky" },
@@ -10,6 +11,9 @@ const socialLinks = [
 export default async function Footer() {
   const t = await getTranslations("footer");
   const locale = await getLocale();
+
+  const rawDate = getLastCommitDate();
+  const lastUpdated = rawDate ? formatCommitDate(rawDate, locale) : null;
 
   return (
     <footer id="contact" className="bg-bg-dark text-text-on-dark">
@@ -55,8 +59,15 @@ export default async function Footer() {
         </div>
 
         <div className="mt-8 border-t border-bg-dark-secondary pt-6 text-center font-mono text-sm text-text-secondary">
-          &copy; {new Date().getFullYear()} Pau Bartrina.{" "}
-          {t("copyright")}
+          <p>
+            &copy; {new Date().getFullYear()} Pau Bartrina.{" "}
+            {t("copyright")}
+          </p>
+          {lastUpdated && (
+            <p className="mt-1 text-xs opacity-60">
+              {t("lastUpdated", { date: lastUpdated })}
+            </p>
+          )}
         </div>
       </div>
     </footer>

--- a/src/i18n/messages/ca.json
+++ b/src/i18n/messages/ca.json
@@ -273,7 +273,8 @@
     "sendMessage": "Envia'm un missatge →",
     "followHeading": "Segueix-me",
     "copyright": "Tots els drets reservats.",
-    "rssLabel": "Feed RSS"
+    "rssLabel": "Feed RSS",
+    "lastUpdated": "Actualitzat: {date}"
   },
   "languageSwitcher": {
     "label": "Idioma",
@@ -390,7 +391,7 @@
     "title": "Ara",
     "description": "Què faig ara - la meva pàgina ara",
     "heading": "Què faig ara",
-    "lastUpdated": "Última actualització: Abril 2025",
+    "lastUpdated": "Última actualització: {date}",
     "location": "Visc a <strong>Sant Pere de Vilamajor</strong>, a la part baixa del <strong>Montseny</strong>.",
     "occupation": "Sóc <code>programador web front-end</code> i actualment cerco feina.",
     "prioritiesHeading": "Les meves prioritats i el estat de projectes",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -273,7 +273,8 @@
     "sendMessage": "Send me a message →",
     "followHeading": "Follow me",
     "copyright": "All rights reserved.",
-    "rssLabel": "RSS Feed"
+    "rssLabel": "RSS Feed",
+    "lastUpdated": "Updated: {date}"
   },
   "languageSwitcher": {
     "label": "Language",
@@ -390,7 +391,7 @@
     "title": "Now",
     "description": "What I'm doing now - my now page",
     "heading": "What I'm doing now",
-    "lastUpdated": "Last updated: April 2025",
+    "lastUpdated": "Last updated: {date}",
     "location": "I live in <strong>Sant Pere de Vilamajor</strong>, at the foot of <strong>Montseny</strong>.",
     "occupation": "I'm a <code>front-end web developer</code> and currently looking for work.",
     "prioritiesHeading": "My priorities and project status",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -273,7 +273,8 @@
     "sendMessage": "Envíame un mensaje →",
     "followHeading": "Sígueme",
     "copyright": "Todos los derechos reservados.",
-    "rssLabel": "Feed RSS"
+    "rssLabel": "Feed RSS",
+    "lastUpdated": "Actualizado: {date}"
   },
   "languageSwitcher": {
     "label": "Idioma",
@@ -390,7 +391,7 @@
     "title": "Ahora",
     "description": "Qué hago ahora - mi página ahora",
     "heading": "Qué hago ahora",
-    "lastUpdated": "Última actualización: Abril 2025",
+    "lastUpdated": "Última actualización: {date}",
     "location": "Vivo en <strong>Sant Pere de Vilamajor</strong>, en la parte baja del <strong>Montseny</strong>.",
     "occupation": "Soy <code>programador web front-end</code> y actualmente busco trabajo.",
     "prioritiesHeading": "Mis prioridades y el estado de proyectos",

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -1,0 +1,33 @@
+import { execSync } from "child_process";
+
+/**
+ * Returns the ISO date string of the most recent git commit, optionally
+ * scoped to specific file paths.
+ *
+ * Runs at BUILD TIME only (server component / `next build`).
+ * Returns null if git is unavailable (e.g. CI without git history).
+ */
+export function getLastCommitDate(files?: string[]): string | null {
+  try {
+    const fileArgs = files ? `-- ${files.join(" ")}` : "";
+    const result = execSync(
+      `git log -1 --format=%ci ${fileArgs}`,
+      { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
+    ).trim();
+    return result || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Formats an ISO date string for display, using the given locale.
+ * Returns a human-readable string like "April 2025" or "Abril 2025".
+ */
+export function formatCommitDate(isoDate: string, locale: string): string {
+  const date = new Date(isoDate);
+  return new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "long",
+  }).format(date);
+}


### PR DESCRIPTION
## Summary

- **#44 `/now` page last-updated from git** — replaces the hardcoded "Última actualització: Abril 2025" with the actual git commit date of the content files (`ca.json` + `ara/page.tsx`). Date is formatted with `Intl.DateTimeFormat` per locale (e.g. "April 2026" / "Abril 2026").
- **#140 Last commit date in footer** — shows "Updated: April 2026" (localized) below the copyright line, derived from the repo's latest commit. Slightly dimmed (60% opacity) to keep it secondary.
- New `src/lib/git.ts` — `getLastCommitDate(files?)` runs `git log -1 --format=%ci` at build time; `formatCommitDate()` localizes the result. Both gracefully return/render `null` if git is unavailable (e.g. shallow CI clones).

Closes #44
Closes #140

## Test plan

- [x] `vitest run` — 165 tests pass
- [x] `pnpm build` — build succeeds; both /now pages and footer pick up the live git date

🤖 Generated with [Claude Code](https://claude.com/claude-code)