### PR TITLE
feat: open-to-work availability banner + blog list JSON-LD schema

### DIFF
--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -3,6 +3,9 @@ import { getTranslations, setRequestLocale } from "next-intl/server";
 import { getAllPosts } from "@/lib/blog";
 import BlogList from "@/components/BlogList";
 import { locales } from "@/i18n/config";
+import { safeJsonLd } from "@/lib/utils";
+
+const BASE_URL = "https://paubartrina.cat";
 
 interface PageProps {
   params: Promise<{ locale: string }>;
@@ -19,8 +22,8 @@ export async function generateMetadata({
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "blog" });
 
-  const ogImageUrl = "https://paubartrina.cat/og-default.png";
-  const canonicalUrl = `https://paubartrina.cat/${locale}/blog`;
+  const ogImageUrl = `${BASE_URL}/og-default.png`;
+  const canonicalUrl = `${BASE_URL}/${locale}/blog`;
 
   return {
     title: t("heading"),
@@ -28,7 +31,7 @@ export async function generateMetadata({
     alternates: {
       canonical: canonicalUrl,
       languages: Object.fromEntries(
-        locales.map((l) => [l, `https://paubartrina.cat/${l}/blog`])
+        locales.map((l) => [l, `${BASE_URL}/${l}/blog`])
       ),
     },
     openGraph: {
@@ -62,24 +65,46 @@ export default async function BlogPage({ params, searchParams }: PageProps) {
   const t = await getTranslations({ locale, namespace: "blog" });
   const posts = getAllPosts(locale);
 
+  // JSON-LD: ItemList of blog posts for search engine rich results
+  const itemListJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: t("heading"),
+    description: t("description"),
+    url: `${BASE_URL}/${locale}/blog`,
+    numberOfItems: posts.length,
+    itemListElement: posts.map((post, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      url: `${BASE_URL}/${locale}/blog/${post.slug}`,
+      name: post.title,
+    })),
+  };
+
   return (
-    <div className="mx-auto max-w-3xl px-6 py-12">
-      <div className="mb-8 flex flex-wrap items-baseline gap-4">
-        <h1 className="font-mono text-4xl font-bold text-text-primary">
-          {t("heading")}
-        </h1>
-        {posts.length > 0 && (
-          <span className="font-mono text-sm text-text-secondary">
-            {t("postCount", { count: posts.length })}
-          </span>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: safeJsonLd(itemListJsonLd) }}
+      />
+      <div className="mx-auto max-w-3xl px-6 py-12">
+        <div className="mb-8 flex flex-wrap items-baseline gap-4">
+          <h1 className="font-mono text-4xl font-bold text-text-primary">
+            {t("heading")}
+          </h1>
+          {posts.length > 0 && (
+            <span className="font-mono text-sm text-text-secondary">
+              {t("postCount", { count: posts.length })}
+            </span>
+          )}
+        </div>
+
+        {posts.length === 0 ? (
+          <p className="font-mono text-text-secondary">{t("emptyState")}</p>
+        ) : (
+          <BlogList posts={posts} allTagsLabel={t("allTags")} selectedTag={tag} />
         )}
       </div>
-
-      {posts.length === 0 ? (
-        <p className="font-mono text-text-secondary">{t("emptyState")}</p>
-      ) : (
-        <BlogList posts={posts} allTagsLabel={t("allTags")} selectedTag={tag} />
-      )}
-    </div>
+    </>
   );
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -8,6 +8,7 @@ import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import ThemeToggle from "@/components/ThemeToggle";
 import ScrollToTop from "@/components/ScrollToTop";
+import AvailabilityBanner from "@/components/AvailabilityBanner";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { routing } from "@/i18n/routing";
@@ -136,6 +137,7 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
               {t("skipToContent")}
             </a>
             <Navbar />
+            <AvailabilityBanner />
             <main id="main-content" className="flex-1">
               {children}
             </main>

--- a/src/components/AvailabilityBanner.tsx
+++ b/src/components/AvailabilityBanner.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Link } from "@/i18n/navigation";
+
+const STORAGE_KEY = "availability-banner-dismissed";
+
+export default function AvailabilityBanner() {
+  const [visible, setVisible] = useState(false);
+  const t = useTranslations("availability");
+
+  useEffect(() => {
+    try {
+      if (!localStorage.getItem(STORAGE_KEY)) {
+        setVisible(true);
+      }
+    } catch {
+      setVisible(true);
+    }
+  }, []);
+
+  const dismiss = () => {
+    setVisible(false);
+    try {
+      localStorage.setItem(STORAGE_KEY, "1");
+    } catch {
+      // localStorage not available — just hide for this session
+    }
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div
+      role="banner"
+      aria-label={t("ariaLabel")}
+      className="relative flex items-center justify-between gap-4 bg-text-accent px-6 py-3 font-mono text-sm text-bg-dark"
+    >
+      <div className="flex items-center gap-2">
+        <span aria-hidden="true" className="text-base">🟢</span>
+        <span className="font-semibold">{t("message")}</span>
+        <Link
+          href="/contacte"
+          className="underline hover:no-underline"
+        >
+          {t("cta")}
+        </Link>
+      </div>
+
+      <button
+        onClick={dismiss}
+        aria-label={t("dismiss")}
+        className="flex-shrink-0 rounded p-1 hover:bg-black/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-bg-dark"
+      >
+        <span aria-hidden="true">✕</span>
+      </button>
+    </div>
+  );
+}

--- a/src/i18n/messages/ca.json
+++ b/src/i18n/messages/ca.json
@@ -422,5 +422,11 @@
     "copyEmail": "Copia el correu",
     "emailCopied": "Copiat!",
     "orEmail": "o escriu-me directament"
+  },
+  "availability": {
+    "message": "Busco feina — disponible per a noves oportunitats.",
+    "cta": "Contacta'm →",
+    "dismiss": "Tancar banner",
+    "ariaLabel": "Banner de disponibilitat"
   }
 }

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -422,5 +422,11 @@
     "copyEmail": "Copy email",
     "emailCopied": "Copied!",
     "orEmail": "or email me directly"
+  },
+  "availability": {
+    "message": "Open to work — available for new opportunities.",
+    "cta": "Get in touch →",
+    "dismiss": "Dismiss banner",
+    "ariaLabel": "Availability status banner"
   }
 }

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -422,5 +422,11 @@
     "copyEmail": "Copiar correo",
     "emailCopied": "¡Copiado!",
     "orEmail": "o escríbeme directamente"
+  },
+  "availability": {
+    "message": "En búsqueda activa — disponible para nuevas oportunidades.",
+    "cta": "Contáctame →",
+    "dismiss": "Cerrar banner",
+    "ariaLabel": "Banner de disponibilidad"
   }
 }


### PR DESCRIPTION
## Summary

- **#114 Open-to-work availability banner** — dismissible banner below the navbar with:
  - 🟢 indicator + message + "Get in touch →" CTA
  - Dismiss state persisted in `localStorage` (hidden on subsequent visits)
  - Fully translated (ca/es/en) via new `availability` i18n namespace
  - Accessible `role="banner"` + `aria-label`

- **#139 JSON-LD `ItemList` on blog list page** — adds structured data with `@type: ItemList`, `numberOfItems`, and per-post `ListItem` entries. This makes the blog listing page eligible for Google rich results (sitelinks, list display).

Closes #114
Closes #139

## Test plan

- [x] `vitest run` — 165 tests pass
- [x] `pnpm build` — builds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)