### PR TITLE
feat(blog): table of contents + share button (#104, #126)

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -6,11 +6,14 @@ import rehypeHighlight from "rehype-highlight";
 import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
 import { getAllSlugs, getPostBySlug, getAvailableLocales, getAdjacentPosts } from "@/lib/blog";
+import { extractHeadings } from "@/lib/headings";
 import { Link } from "@/i18n/navigation";
 import { locales } from "@/i18n/config";
 import ReadingProgress from "@/components/ReadingProgress";
 import PostNavigation from "@/components/PostNavigation";
 import CodeBlock from "@/components/CodeBlock";
+import TableOfContents from "@/components/TableOfContents";
+import ShareButton from "@/components/ShareButton";
 import { safeJsonLd } from "@/lib/utils";
 
 interface PageProps {
@@ -78,6 +81,9 @@ export default async function BlogPostPage({ params }: PageProps) {
   const t = await getTranslations({ locale, namespace: "blog" });
   const { prev, next } = getAdjacentPosts(locale, slug);
 
+  const headings = extractHeadings(post.content);
+  const postUrl = `https://paubartrina.cat/${locale}/blog/${slug}`;
+
   const blogPostingJsonLd = {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
@@ -85,7 +91,7 @@ export default async function BlogPostPage({ params }: PageProps) {
     description: post.description,
     datePublished: post.date,
     inLanguage: locale,
-    url: `https://paubartrina.cat/${locale}/blog/${slug}`,
+    url: postUrl,
     author: {
       "@type": "Person",
       name: "Pau Bartrina",
@@ -106,64 +112,84 @@ export default async function BlogPostPage({ params }: PageProps) {
 
   return (
     <>
-    <ReadingProgress />
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: safeJsonLd(blogPostingJsonLd) }}
-    />
-    <div className="mx-auto max-w-3xl px-6 py-12">
-      <Link
-        href="/blog"
-        className="mb-8 inline-block font-mono text-sm text-text-accent hover:underline"
-      >
-        {t("backToList")}
-      </Link>
+      <ReadingProgress />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: safeJsonLd(blogPostingJsonLd) }}
+      />
+      <div className="mx-auto max-w-7xl px-6 py-12">
+        <div className="flex gap-16">
+          {/* Main article column */}
+          <div className="min-w-0 flex-1">
+            <Link
+              href="/blog"
+              className="mb-8 inline-block font-mono text-sm text-text-accent hover:underline"
+            >
+              {t("backToList")}
+            </Link>
 
-      {/* Translation warning banner */}
-      {locale !== "ca" && (
-        <div className="mb-6 rounded-md border border-amber-500/30 bg-amber-50 p-4 dark:bg-amber-950/20">
-          <p className="text-sm text-amber-800 dark:text-amber-200">
-            {t("translationWarning")}
-          </p>
-          <Link
-            href={`/blog/${slug}`}
-            locale="ca"
-            className="mt-2 inline-block text-sm text-amber-600 hover:underline dark:text-amber-400"
-          >
-            {t("readOriginal")}
-          </Link>
-        </div>
-      )}
+            {/* Translation warning banner */}
+            {locale !== "ca" && (
+              <div className="mb-6 rounded-md border border-amber-500/30 bg-amber-50 p-4 dark:bg-amber-950/20">
+                <p className="text-sm text-amber-800 dark:text-amber-200">
+                  {t("translationWarning")}
+                </p>
+                <Link
+                  href={`/blog/${slug}`}
+                  locale="ca"
+                  className="mt-2 inline-block text-sm text-amber-600 hover:underline dark:text-amber-400"
+                >
+                  {t("readOriginal")}
+                </Link>
+              </div>
+            )}
 
-      <header className="mb-8">
-        <h1 className="mb-4 font-mono text-3xl font-bold text-text-primary md:text-4xl">
-          {post.title}
-        </h1>
-        <div className="flex flex-wrap gap-3 font-mono text-sm text-text-secondary">
-          <time>{post.date}</time>
-          <span>{t("readingTime", { count: post.readingTimeMinutes })}</span>
-          <span>{t("wordCount", { count: post.wordCount })}</span>
-        </div>
-        {post.tags.length > 0 && (
-          <div className="mt-4 flex flex-wrap gap-2">
-            {post.tags.map((tag) => (
-              <span
-                key={tag}
-                className="rounded-full border border-border-color px-3 py-1 font-mono text-xs text-text-secondary"
-              >
-                {tag}
-              </span>
-            ))}
+            <header className="mb-8">
+              <h1 className="mb-4 font-mono text-3xl font-bold text-text-primary md:text-4xl">
+                {post.title}
+              </h1>
+              <div className="flex flex-wrap items-center gap-3 font-mono text-sm text-text-secondary">
+                <time>{post.date}</time>
+                <span>{t("readingTime", { count: post.readingTimeMinutes })}</span>
+                <span>{t("wordCount", { count: post.wordCount })}</span>
+                <ShareButton
+                  url={postUrl}
+                  title={post.title}
+                  labelShare={t("share")}
+                  labelCopied={t("linkCopied")}
+                  labelCopyLink={t("copyLink")}
+                />
+              </div>
+              {post.tags.length > 0 && (
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {post.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="rounded-full border border-border-color px-3 py-1 font-mono text-xs text-text-secondary"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </header>
+
+            <article className="prose prose-lg max-w-none">
+              {content}
+            </article>
+
+            <PostNavigation prev={prev} next={next} locale={locale} />
           </div>
-        )}
-      </header>
 
-      <article className="prose prose-lg max-w-none">
-        {content}
-      </article>
-
-      <PostNavigation prev={prev} next={next} locale={locale} />
-    </div>
+          {/* Sidebar TOC — desktop only, only when post has headings */}
+          {headings.length > 0 && (
+            <TableOfContents
+              headings={headings}
+              title={t("tableOfContents")}
+            />
+          )}
+        </div>
+      </div>
     </>
   );
 }

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState } from "react";
+
+interface ShareButtonProps {
+  url: string;
+  title: string;
+  labelShare: string;
+  labelCopied: string;
+  labelCopyLink: string;
+}
+
+export default function ShareButton({
+  url,
+  title,
+  labelShare,
+  labelCopied,
+  labelCopyLink,
+}: ShareButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleShare = async () => {
+    // Try Web Share API first (mobile / modern browsers)
+    if (typeof navigator !== "undefined" && navigator.share) {
+      try {
+        await navigator.share({ title, url });
+        return;
+      } catch {
+        // User cancelled or API unavailable — fall through to clipboard
+      }
+    }
+
+    // Clipboard copy fallback
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Last resort: open mailto share
+      window.open(
+        `mailto:?subject=${encodeURIComponent(title)}&body=${encodeURIComponent(url)}`,
+        "_blank"
+      );
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleShare}
+      aria-label={copied ? labelCopied : labelShare}
+      className="inline-flex items-center gap-2 rounded-md border border-border-color px-3 py-1.5 font-mono text-sm text-text-secondary transition-colors hover:border-text-accent hover:text-text-accent"
+    >
+      {copied ? (
+        <>
+          {/* Check icon */}
+          <svg
+            aria-hidden="true"
+            className="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+          {labelCopied}
+        </>
+      ) : (
+        <>
+          {/* Share / link icon */}
+          <svg
+            aria-hidden="true"
+            className="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
+            />
+          </svg>
+          {labelCopyLink}
+        </>
+      )}
+    </button>
+  );
+}

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { Heading } from "@/lib/headings";
+
+interface TableOfContentsProps {
+  headings: Heading[];
+  title: string;
+}
+
+export default function TableOfContents({ headings, title }: TableOfContentsProps) {
+  const [activeId, setActiveId] = useState<string>("");
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    if (headings.length === 0) return;
+
+    const headingEls = headings
+      .map((h) => document.getElementById(h.id))
+      .filter(Boolean) as HTMLElement[];
+
+    // Disconnect previous observer
+    observerRef.current?.disconnect();
+
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        // Find the topmost visible heading
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+
+        if (visible.length > 0) {
+          setActiveId(visible[0].target.id);
+        }
+      },
+      {
+        rootMargin: "0px 0px -70% 0px",
+        threshold: 0,
+      }
+    );
+
+    headingEls.forEach((el) => observerRef.current!.observe(el));
+
+    return () => observerRef.current?.disconnect();
+  }, [headings]);
+
+  if (headings.length === 0) return null;
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>, id: string) => {
+    e.preventDefault();
+    const el = document.getElementById(id);
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth" });
+      el.focus({ preventScroll: true });
+    }
+  };
+
+  return (
+    <nav
+      aria-label={title}
+      className="sticky top-24 hidden w-64 shrink-0 xl:block"
+    >
+      <p className="mb-3 font-mono text-xs font-semibold uppercase tracking-widest text-text-secondary">
+        {title}
+      </p>
+      <ul className="space-y-1 border-l border-border-color pl-4">
+        {headings.map((heading) => (
+          <li key={heading.id}>
+            <a
+              href={`#${heading.id}`}
+              onClick={(e) => handleClick(e, heading.id)}
+              className={[
+                "block py-0.5 font-mono text-sm leading-snug transition-colors hover:text-text-accent",
+                heading.level === 3 ? "pl-4" : "",
+                activeId === heading.id
+                  ? "text-text-accent"
+                  : "text-text-secondary",
+              ]
+                .filter(Boolean)
+                .join(" ")}
+            >
+              {heading.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/src/i18n/messages/ca.json
+++ b/src/i18n/messages/ca.json
@@ -303,7 +303,11 @@
     "postCount": "{count, plural, one {# article} other {# articles}}",
     "wordCount": "{count} paraules",
     "prevPost": "← Anterior",
-    "nextPost": "Següent →"
+    "nextPost": "Següent →",
+    "tableOfContents": "En aquesta pàgina",
+    "share": "Compartir",
+    "copyLink": "Copiar l'enllaç",
+    "linkCopied": "Enllaç copiat!"
   },
   "contact": {
     "heading": "Contacte",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -303,7 +303,11 @@
     "postCount": "{count, plural, one {# post} other {# posts}}",
     "wordCount": "{count} words",
     "prevPost": "← Previous",
-    "nextPost": "Next →"
+    "nextPost": "Next →",
+    "tableOfContents": "On this page",
+    "share": "Share",
+    "copyLink": "Copy link",
+    "linkCopied": "Link copied!"
   },
   "contact": {
     "heading": "Contact",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -303,7 +303,11 @@
     "postCount": "{count, plural, one {# artículo} other {# artículos}}",
     "wordCount": "{count} palabras",
     "prevPost": "← Anterior",
-    "nextPost": "Siguiente →"
+    "nextPost": "Siguiente →",
+    "tableOfContents": "En esta página",
+    "share": "Compartir",
+    "copyLink": "Copiar enlace",
+    "linkCopied": "¡Enlace copiado!"
   },
   "contact": {
     "heading": "Contacto",

--- a/src/lib/headings.ts
+++ b/src/lib/headings.ts
@@ -1,0 +1,47 @@
+export interface Heading {
+  id: string;
+  text: string;
+  level: 2 | 3;
+}
+
+/**
+ * Converts heading text to a slug compatible with rehype-slug / GitHub Slugger.
+ */
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, "")   // remove non-word chars except hyphens
+    .replace(/[\s_]+/g, "-")    // spaces/underscores → hyphens
+    .replace(/^-+|-+$/g, "");   // trim leading/trailing hyphens
+}
+
+/**
+ * Parses h2 and h3 headings from raw MDX/Markdown content.
+ * Returns headings in document order with de-duplicated IDs (same algorithm
+ * as github-slugger used by rehype-slug).
+ */
+export function extractHeadings(content: string): Heading[] {
+  const pattern = /^(#{2,3})\s+(.+)$/gm;
+  const seen = new Map<string, number>();
+  const headings: Heading[] = [];
+
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(content)) !== null) {
+    const level = match[1].length as 2 | 3;
+    // Strip inline MDX/HTML tags and backticks from heading text
+    const rawText = match[2]
+      .replace(/<[^>]+>/g, "")    // strip HTML tags
+      .replace(/`([^`]+)`/g, "$1") // strip backtick code spans
+      .trim();
+
+    const baseSlug = slugify(rawText);
+    const count = seen.get(baseSlug) ?? 0;
+    const id = count === 0 ? baseSlug : `${baseSlug}-${count}`;
+    seen.set(baseSlug, count + 1);
+
+    headings.push({ id, text: rawText, level });
+  }
+
+  return headings;
+}


### PR DESCRIPTION
## Summary

- **TableOfContents** (`src/components/TableOfContents.tsx`): sticky sidebar visible on `xl` screens, parses `##`/`###` headings via `extractHeadings`, tracks active section with `IntersectionObserver`, smooth scrolls on link click
- **ShareButton** (`src/components/ShareButton.tsx`): uses Web Share API on mobile/modern browsers, falls back to `navigator.clipboard.writeText` with a 2-second "Link copied!" feedback state
- **`src/lib/headings.ts`**: `extractHeadings()` utility generates rehype-slug-compatible IDs (same slugify algorithm as github-slugger used by `rehype-slug`)
- Blog post page layout widened to `max-w-7xl` with a flex row so the TOC sidebar sits alongside the article
- i18n keys added in all three locales (CA/ES/EN): `tableOfContents`, `share`, `copyLink`, `linkCopied`

Closes #104, Closes #126

## Test plan

- [ ] Build passes with `pnpm build` (0 errors, 0 warnings)
- [ ] TypeScript compiles clean (`pnpm tsc --noEmit`)
- [ ] On a blog post with multiple `##`/`###` headings, TOC appears on desktop (≥ 1280px)
- [ ] Active heading highlights as user scrolls through article
- [ ] Clicking TOC link smooth-scrolls to heading
- [ ] Share button: on desktop copies link, shows "Link copied!" for 2 s
- [ ] Share button: on mobile opens native share sheet
- [ ] Posts with no headings render without TOC (no empty sidebar)
- [ ] All three locales show correct TOC label and share button labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)