### PR TITLE
feat: printable/PDF CV page at /cv (#99)

### DIFF
--- a/src/app/[locale]/cv/page.tsx
+++ b/src/app/[locale]/cv/page.tsx
@@ -1,0 +1,200 @@
+import type { Metadata } from "next";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
+import { locales } from "@/i18n/config";
+import PrintButton from "@/components/PrintButton";
+
+interface PageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export function generateStaticParams() {
+  return locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "cv" });
+  return {
+    title: t("title"),
+    description: t("description"),
+    robots: { index: false },
+  };
+}
+
+interface Job {
+  period: string;
+  role: string;
+  company: string;
+  location: string;
+  description: string;
+}
+
+interface EducationEntry {
+  year: string;
+  title: string;
+  institution: string;
+}
+
+interface SkillCategory {
+  title: string;
+  items: string[];
+}
+
+interface Language {
+  label: string;
+  level: string;
+}
+
+export default async function CVPage({ params }: PageProps) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const t = await getTranslations({ locale, namespace: "cv" });
+  const tExp = await getTranslations({ locale, namespace: "experience" });
+  const tEdu = await getTranslations({ locale, namespace: "education" });
+  const tSkills = await getTranslations({ locale, namespace: "skills" });
+  const tAbout = await getTranslations({ locale, namespace: "about" });
+
+  const jobs = tExp.raw("jobs") as Job[];
+  const entries = tEdu.raw("entries") as EducationEntry[];
+  const categories = tSkills.raw("categories") as SkillCategory[];
+  const languages = tAbout.raw("languages") as Language[];
+
+  return (
+    <div className="mx-auto max-w-4xl px-6 py-12 print:px-0 print:py-0">
+      {/* Screen-only toolbar */}
+      <div className="print:hidden mb-8 flex items-center justify-between">
+        <Link
+          href="/"
+          className="font-mono text-sm text-text-accent hover:underline"
+        >
+          ← {t("backHome")}
+        </Link>
+        <PrintButton label={t("printButton")} />
+      </div>
+
+      {/* CV Header */}
+      <header className="mb-8 border-b border-border-color pb-6">
+        <h1 className="font-display text-4xl font-bold text-text-primary">
+          Pau Bartrina
+        </h1>
+        <p className="mt-1 font-mono text-lg text-text-accent">
+          Senior Frontend Engineer
+        </p>
+        <div className="mt-3 flex flex-wrap gap-x-6 gap-y-1 font-mono text-sm text-text-secondary">
+          <a href="https://paubartrina.cat" className="hover:underline print:no-underline">
+            paubartrina.cat
+          </a>
+          <a href="https://linkedin.com/in/paubartrina" className="hover:underline print:no-underline">
+            linkedin.com/in/paubartrina
+          </a>
+          <a href="https://github.com/PBartrina" className="hover:underline print:no-underline">
+            github.com/PBartrina
+          </a>
+        </div>
+      </header>
+
+      {/* Summary */}
+      <section className="mb-8">
+        <p className="font-mono text-sm leading-relaxed text-text-secondary">
+          {tAbout("bio")}
+        </p>
+      </section>
+
+      {/* Skills */}
+      <section className="mb-8">
+        <h2 className="mb-4 font-display text-xl font-bold text-text-primary">
+          {tSkills("heading")}
+        </h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          {categories.map((cat) => (
+            <div key={cat.title}>
+              <p className="mb-1 font-mono text-xs font-semibold uppercase tracking-wide text-text-accent">
+                {cat.title}
+              </p>
+              <p className="font-mono text-xs text-text-secondary">
+                {cat.items.join(" · ")}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Experience */}
+      <section className="mb-8">
+        <h2 className="mb-4 font-display text-xl font-bold text-text-primary">
+          {tExp("heading")}
+        </h2>
+        <ol className="space-y-5">
+          {jobs.map((job) => (
+            <li key={`${job.period}-${job.company}`} className="print:break-inside-avoid">
+              <div className="flex flex-wrap items-baseline justify-between gap-2">
+                <div>
+                  <span className="font-display font-semibold text-text-primary">
+                    {job.role}
+                  </span>
+                  <span className="mx-2 text-text-secondary">·</span>
+                  <span className="font-mono text-sm text-text-secondary">
+                    {job.company}
+                  </span>
+                  <span className="mx-2 text-text-secondary">·</span>
+                  <span className="font-mono text-sm text-text-secondary">
+                    {job.location}
+                  </span>
+                </div>
+                <span className="font-mono text-xs text-text-secondary">
+                  {job.period}
+                </span>
+              </div>
+              <p className="mt-1 font-mono text-sm leading-relaxed text-text-secondary">
+                {job.description}
+              </p>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      {/* Education */}
+      <section className="mb-8">
+        <h2 className="mb-4 font-display text-xl font-bold text-text-primary">
+          {tEdu("heading")}
+        </h2>
+        <ol className="space-y-3">
+          {entries.map((entry) => (
+            <li key={`${entry.year}-${entry.title}`} className="flex flex-wrap items-baseline justify-between gap-2">
+              <div>
+                <span className="font-display font-semibold text-text-primary">
+                  {entry.title}
+                </span>
+                <span className="mx-2 text-text-secondary">·</span>
+                <span className="font-mono text-sm text-text-secondary">
+                  {entry.institution}
+                </span>
+              </div>
+              <span className="font-mono text-xs text-text-secondary">
+                {entry.year}
+              </span>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      {/* Languages */}
+      <section>
+        <h2 className="mb-4 font-display text-xl font-bold text-text-primary">
+          {tAbout("languagesLabel")}
+        </h2>
+        <ul className="flex flex-wrap gap-4">
+          {languages.map((lang) => (
+            <li key={lang.label} className="font-mono text-sm">
+              <span className="text-text-primary">{lang.label}</span>
+              <span className="mx-1.5 text-text-secondary">·</span>
+              <span className="text-text-secondary">{lang.level}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -58,16 +58,22 @@ export default async function Footer() {
           </div>
         </div>
 
-        <div className="mt-8 border-t border-bg-dark-secondary pt-6 text-center font-mono text-sm text-text-secondary">
-          <p>
+        <div className="mt-8 border-t border-bg-dark-secondary pt-6 flex flex-col items-center gap-2 font-mono text-sm text-text-secondary">
+          <div>
             &copy; {new Date().getFullYear()} Pau Bartrina.{" "}
             {t("copyright")}
-          </p>
+          </div>
           {lastUpdated && (
-            <p className="mt-1 text-xs opacity-60">
+            <p className="text-xs opacity-60">
               {t("lastUpdated", { date: lastUpdated })}
             </p>
           )}
+          <Link
+            href="/cv"
+            className="text-xs text-text-secondary opacity-60 hover:opacity-100 hover:text-text-accent transition-opacity"
+          >
+            {t("cvLink")}
+          </Link>
         </div>
       </div>
     </footer>

--- a/src/components/PrintButton.tsx
+++ b/src/components/PrintButton.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+interface PrintButtonProps {
+  label: string;
+}
+
+export default function PrintButton({ label }: PrintButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={() => window.print()}
+      className="print:hidden inline-flex items-center gap-2 rounded-md border border-border-color px-4 py-2 font-mono text-sm text-text-secondary transition-colors hover:border-text-accent hover:text-text-accent"
+    >
+      <svg
+        aria-hidden="true"
+        className="h-4 w-4"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"
+        />
+      </svg>
+      {label}
+    </button>
+  );
+}

--- a/src/i18n/messages/ca.json
+++ b/src/i18n/messages/ca.json
@@ -274,7 +274,8 @@
     "followHeading": "Segueix-me",
     "copyright": "Tots els drets reservats.",
     "rssLabel": "Feed RSS",
-    "lastUpdated": "Actualitzat: {date}"
+    "lastUpdated": "Actualitzat: {date}",
+    "cvLink": "Veure / Imprimir CV"
   },
   "languageSwitcher": {
     "label": "Idioma",
@@ -441,6 +442,12 @@
         "relationship": "Col·laborador"
       }
     ]
+  },
+  "cv": {
+    "title": "CV — Pau Bartrina",
+    "description": "CV imprimible de Pau Bartrina, Senior Frontend Engineer.",
+    "printButton": "Imprimir / Desar com a PDF",
+    "backHome": "Tornar a l'inici"
   },
   "codeBlock": {
     "copy": "Copia",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -274,7 +274,8 @@
     "followHeading": "Follow me",
     "copyright": "All rights reserved.",
     "rssLabel": "RSS Feed",
-    "lastUpdated": "Updated: {date}"
+    "lastUpdated": "Updated: {date}",
+    "cvLink": "View / Print CV"
   },
   "languageSwitcher": {
     "label": "Language",
@@ -441,6 +442,12 @@
         "relationship": "Collaborator"
       }
     ]
+  },
+  "cv": {
+    "title": "CV — Pau Bartrina",
+    "description": "Printable CV for Pau Bartrina, Senior Frontend Engineer.",
+    "printButton": "Print / Save as PDF",
+    "backHome": "Back to home"
   },
   "codeBlock": {
     "copy": "Copy",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -274,7 +274,8 @@
     "followHeading": "Sígueme",
     "copyright": "Todos los derechos reservados.",
     "rssLabel": "Feed RSS",
-    "lastUpdated": "Actualizado: {date}"
+    "lastUpdated": "Actualizado: {date}",
+    "cvLink": "Ver / Imprimir CV"
   },
   "languageSwitcher": {
     "label": "Idioma",
@@ -441,6 +442,12 @@
         "relationship": "Colaborador"
       }
     ]
+  },
+  "cv": {
+    "title": "CV — Pau Bartrina",
+    "description": "CV imprimible de Pau Bartrina, Senior Frontend Engineer.",
+    "printButton": "Imprimir / Guardar como PDF",
+    "backHome": "Volver al inicio"
   },
   "codeBlock": {
     "copy": "Copiar",


### PR DESCRIPTION
## Summary

- New page `src/app/[locale]/cv/page.tsx` at `/[locale]/cv`
- Renders a clean, print-optimized CV layout sourcing all data from existing i18n messages (experience, education, skills, languages, bio) — zero content duplication
- `PrintButton` client component triggers `window.print()`, hidden in print media (`print:hidden`)
- Tailwind `print:` variants used for layout adjustments: `print:px-0`, `print:break-inside-avoid`, etc.
- Clicking "Print / Save as PDF" opens the browser's native print/PDF dialog
- Footer gets a discreet "View / Print CV" link (low visual weight, opacity-60)
- Page is `noindex` (supplemental, not intended for search engines)
- i18n keys in all three locales: `cv.*`, `footer.cvLink`

Closes #99

## Test plan

- [ ] Build passes (`pnpm build`, 0 errors)
- [ ] `/ca/cv`, `/es/cv`, `/en/cv` all render the CV correctly
- [ ] Print button opens browser print dialog
- [ ] Printing produces a clean single-page (or near single-page) PDF layout
- [ ] Navigation toolbar and print button are hidden in print output
- [ ] Footer shows "View / Print CV" link in all three locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)