### PR TITLE
feat: page transition fade-in animation on route changes (#125)

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -9,6 +9,7 @@ import Footer from "@/components/Footer";
 import ThemeToggle from "@/components/ThemeToggle";
 import ScrollToTop from "@/components/ScrollToTop";
 import AvailabilityBanner from "@/components/AvailabilityBanner";
+import PageTransition from "@/components/PageTransition";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { routing } from "@/i18n/routing";
@@ -139,7 +140,7 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
             <Navbar />
             <AvailabilityBanner />
             <main id="main-content" className="flex-1">
-              {children}
+              <PageTransition>{children}</PageTransition>
             </main>
             <Footer />
             <ThemeToggle />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -229,3 +229,25 @@ h1, h2, h3, h4 {
     animation: none !important;
   }
 }
+
+/* ─── Page transition animation ─────────────────────────────────────── */
+@keyframes page-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.page-transition-wrapper {
+  animation: page-enter 0.25s ease-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page-transition-wrapper {
+    animation: none;
+  }
+}

--- a/src/components/PageTransition.tsx
+++ b/src/components/PageTransition.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+/**
+ * Wraps page content with a CSS fade-in + slide-up animation on route changes.
+ * Uses the pathname as React key so the component remounts (re-animates)
+ * whenever the user navigates to a different page.
+ *
+ * Animation is defined in globals.css as @keyframes page-enter
+ * and honoured via `motion-reduce` media query.
+ */
+export default function PageTransition({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+
+  return (
+    <div
+      key={pathname}
+      className="page-transition-wrapper"
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- `PageTransition` client component (`src/components/PageTransition.tsx`): wraps `children` with `key={usePathname()}` — React remounts the wrapper on every navigation, triggering the CSS animation
- `@keyframes page-enter` in `globals.css`: 250ms ease-out fade-in + 8px upward slide, applied via `.page-transition-wrapper`
- Respects `prefers-reduced-motion: reduce` — animation is skipped entirely for users who prefer less motion
- Zero external dependencies: no Framer Motion, no third-party library
- Wired in `src/app/[locale]/layout.tsx` — wraps the entire `{children}` inside `<main>`

Closes #125

## Test plan

- [ ] Build passes (`pnpm build`, 0 errors)
- [ ] Navigating between pages produces a subtle 250ms fade-in + slide-up
- [ ] System accessibility setting "Reduce motion" disables the animation
- [ ] No flicker or layout shift during transitions
- [ ] Animation also fires on first page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)