### PR TITLE
feat: reveal-on-scroll animations for homepage sections (#121)

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -7,6 +7,7 @@ import Projects from "@/components/Projects";
 import Experience from "@/components/Experience";
 import Education from "@/components/Education";
 import Testimonials from "@/components/Testimonials";
+import RevealOnScroll from "@/components/RevealOnScroll";
 import { getAllPosts } from "@/lib/blog";
 import { safeJsonLd } from "@/lib/utils";
 import { locales } from "@/i18n/config";
@@ -46,18 +47,28 @@ export default async function Home({ params }: PageProps) {
       />
       <Hero />
       <AtAGlance latestPost={latestPost} locale={locale} />
-      <Skills />
+      <RevealOnScroll>
+        <Skills />
+      </RevealOnScroll>
       <Suspense fallback={<div className="py-20" />}>
-        <Projects />
+        <RevealOnScroll delay={50}>
+          <Projects />
+        </RevealOnScroll>
       </Suspense>
       <Suspense fallback={<div className="py-20" />}>
-        <Testimonials />
+        <RevealOnScroll delay={100}>
+          <Testimonials />
+        </RevealOnScroll>
       </Suspense>
       <Suspense fallback={<div className="py-20" />}>
-        <Experience />
+        <RevealOnScroll delay={150}>
+          <Experience />
+        </RevealOnScroll>
       </Suspense>
       <Suspense fallback={<div className="py-20" />}>
-        <Education />
+        <RevealOnScroll delay={200}>
+          <Education />
+        </RevealOnScroll>
       </Suspense>
     </>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -251,3 +251,25 @@ h1, h2, h3, h4 {
     animation: none;
   }
 }
+
+/* ─── Reveal-on-scroll sections ──────────────────────────────────────── */
+.reveal-on-scroll {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.5s ease-out, transform 0.5s ease-out;
+  /* Avoid layout shift: the element still occupies space */
+  will-change: opacity, transform;
+}
+
+.reveal-on-scroll.reveal-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal-on-scroll {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}

--- a/src/components/RevealOnScroll.tsx
+++ b/src/components/RevealOnScroll.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+interface RevealOnScrollProps {
+  children: React.ReactNode;
+  /** Additional class names applied regardless of visibility */
+  className?: string;
+  /** Delay in ms before animation starts once visible (default: 0) */
+  delay?: number;
+}
+
+/**
+ * Wraps children in a div that fades in + slides up when the element
+ * enters the viewport via IntersectionObserver.
+ *
+ * Uses CSS class `reveal-visible` (defined in globals.css) to trigger
+ * the animation; starts in an invisible but laid-out state so the page
+ * layout is not affected before the section becomes visible.
+ *
+ * Respects prefers-reduced-motion — immediately shows content without
+ * any animation when the user prefers reduced motion.
+ */
+export default function RevealOnScroll({
+  children,
+  className = "",
+  delay = 0,
+}: RevealOnScrollProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(false);
+  const [prefersReduced, setPrefersReduced] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setPrefersReduced(mq.matches);
+    if (mq.matches) {
+      setVisible(true);
+      return;
+    }
+
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          if (delay > 0) {
+            setTimeout(() => setVisible(true), delay);
+          } else {
+            setVisible(true);
+          }
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "0px 0px -80px 0px", threshold: 0.05 }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [delay]);
+
+  if (prefersReduced) {
+    return <div className={className}>{children}</div>;
+  }
+
+  return (
+    <div
+      ref={ref}
+      className={[
+        "reveal-on-scroll",
+        visible ? "reveal-visible" : "",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- `RevealOnScroll` client component (`src/components/RevealOnScroll.tsx`): wraps any content; uses `IntersectionObserver` (rootMargin: 80px bottom, threshold: 5%) to trigger visible transition once element enters the viewport
- Sections start in `opacity: 0; transform: translateY(20px)` state — layout space is reserved, no CLS
- On viewport entry: CSS transition `opacity 0.5s ease-out, transform 0.5s ease-out` to final state
- Homepage wraps Skills, Projects, Experience, Education with staggered `delay` props (0/50/100/150ms) for a cascade feel
- `prefers-reduced-motion: reduce`: component returns content immediately visible with no animation; JS also bails out of the observer entirely
- CSS in `globals.css`: `.reveal-on-scroll` / `.reveal-visible` classes + reduced motion override
- `will-change: opacity, transform` on `.reveal-on-scroll` to hint GPU compositing

Closes #121

## Test plan

- [ ] Build passes (`pnpm build`, 0 errors)
- [ ] Scrolling past the fold reveals Skills → Projects → Experience → Education with cascade delays
- [ ] No content flash or layout shift before sections are revealed
- [ ] System "Reduce motion" setting shows all sections immediately without animation
- [ ] All three locales work identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)