### PR TITLE
Blog series on the site build + /now page refresh

### DIFF
--- a/content/blog/ca/bots-que-proposen-jo-decideixo.mdx
+++ b/content/blog/ca/bots-que-proposen-jo-decideixo.mdx
@@ -1,0 +1,63 @@
+---
+title: "Bots que proposen, jo decideixo"
+date: "2026-08-09"
+description: "Com tres accions de GitHub troben feina, la fan, i per què el fre és la part important"
+tags: ["automatitzacio", "github-actions", "ia", "claude"]
+published: true
+---
+
+Al primer article d'aquesta web vaig escriure que estava dissenyant "un sistema automatitzat de millores i gestió de Issues a GitHub". Això existeix, fa cinc mesos que funciona, i aquest article explica com.
+
+Avís d'entrada: la part interessant no és que la IA escrigui codi. Això ja ho sabem tots. La part interessant és **on hi vaig posar el fre**.
+
+## Tres bots, un dilluns al matí
+
+Tot passa mentre esmorzo, encadenat amb una hora de diferència:
+
+| Hora (UTC) | Qui | Què fa |
+|---|---|---|
+| 07:00 | Improvement Proposer | Llegeix el codi i proposa fins a **3 millores** |
+| 08:00 | Code Quality Scanner | Busca problemes i obre fins a **5 issues** |
+| 09:00 | Auto Fixer | Agafa feina aprovada i obre un **pull request** |
+
+Els dos primers només tenen permís per **obrir issues**. No poden tocar el codi ni encara que vulguin: al fitxer del *workflow*, el permís de continguts és de només lectura. Això no és una qüestió de confiança, és una qüestió de disseny — un bot que no pot escriure no pot trencar res.
+
+L'**Improvement Proposer** mira el projecte i suggereix coses que hi podrien anar bé: accessibilitat, rendiment, SEO, funcionalitats que falten. Etiqueta els issues amb `enhancement` i `automated`.
+
+El **Code Quality Scanner** fa la feina contrària: busca el que ja hi és i està malament. Etiquetes `bug` i `automated`.
+
+Tots dos tenen una cosa que va resultar més important del que esperava: **comproven els issues que ja existeixen** — oberts i tancats — i comparen les paraules del títol per no tornar a proposar el mateix. Sense això, cada dilluns rebia les mateixes cinc idees. Un bot amb memòria de peix és pitjor que cap bot, perquè el soroll setmanal fa que deixis de llegir-lo.
+
+## L'etiqueta que ho canvia tot
+
+Aquí és on el sistema es guanya el sou. L'**Auto Fixer** no toca cap issue tret que tingui **tres etiquetes**: `bug` o `enhancement`, més `automated`, **més `approved`**.
+
+I l'etiqueta `approved` només la poso jo, a mà.
+
+Vol dir que cada dilluns a les nou el *fixer* es desperta, mira si hi ha feina que jo hagi beneït explícitament, i si no n'hi ha, es torna a dormir. El sistema no decideix què és important. Proposa, i espera.
+
+A sobre, quan corre sol, **només processa un issue per execució**. Podria fer-ne cinc. No en fa cinc perquè després jo he de revisar cinc *pull requests*, i un humà revisant cinc PRs de cop no revisa: aprova.
+
+## Què fa exactament quan arrenca
+
+Quan hi ha un issue aprovat, el *fixer* llegeix l'issue, llegeix els fitxers implicats, escriu el canvi, crea una branca (`fix/...` o `feat/...`), fa el *commit* i obre un *pull request* que referencia l'issue original.
+
+I llavors s'atura. No fusiona. **Mai fusiona.**
+
+Els dos bots de detecció fan servir **Claude Sonnet**, que és ràpid i barat per llegir molt de codi. El que escriu els canvis fa servir **Claude Opus**, perquè escriure codi correcte val la pena pagar-lo. Trobar problemes és fàcil; arreglar-los sense trencar res, no.
+
+## L'última porta
+
+Cada PR que obre el bot passa per la mateixa CI que els meus: comprovació de tipus, *lint*, tests i *build*. Si el bot ha escrit alguna cosa que no compila, ho sabem abans que jo ho llegeixi.
+
+Així que la cadena completa, de principi a fi, és aquesta:
+
+**El bot proposa → jo aprovo → el bot ho escriu → la CI ho verifica → jo el fusiono.**
+
+Hi ha exactament dos punts on hi ha un humà, i tots dos són decisions, no feina. Aquesta és tota la idea. No volia un sistema que treballés per mi mentre dormo; volia un sistema que **em portés la feina ja pensada** perquè jo només hagués de dir que sí o que no.
+
+## El que no explica ningú
+
+Un sistema així sembla molt més impressionant en un diagrama que en la pràctica. Els bots proposen coses òbvies, coses innecessàries i, de tant en tant, alguna cosa que no se m'havia acudit i que és bona de veritat. La proporció entre aquestes tres categories és la mètrica que realment importa.
+
+Tinc cinc mesos de dades sobre exactament això, i les explico al pròxim article. La conclusió curta: **la majoria de les seves idees les rebutjo**, i és precisament per això que el sistema funciona.

--- a/content/blog/ca/cinc-mesos-de-bots-els-numeros.mdx
+++ b/content/blog/ca/cinc-mesos-de-bots-els-numeros.mdx
@@ -1,0 +1,69 @@
+---
+title: "Cinc mesos de bots: els números"
+date: "2026-08-10"
+description: "169 issues, 53 pull requests fusionats i què he après rebutjant dos terços de les propostes"
+tags: ["automatitzacio", "dades", "retrospectiva", "claude"]
+published: true
+---
+
+Als dos articles anteriors he explicat com està feta aquesta web i com funcionen els bots que la mantenen. Aquest és el que realment volia escriure: **què ha produït tot això**, amb les xifres reals del repositori i sense endolcir-les.
+
+Període: del 9 de març al 10 d'agost del 2026. Cinc mesos justos.
+
+## Les xifres
+
+**169 issues** oberts automàticament. Repartits gairebé a parts iguals: **83 errors** i **86 propostes de millora**. Una simetria que no vaig planificar i que em va sorprendre.
+
+D'aquests 169, n'he aprovat **55**. És a dir, **un 33%**.
+
+**53 pull requests fusionats**, amb **+5.238 línies afegides i −1.501 eliminades**.
+
+## El número que importa és el 33%
+
+Dos de cada tres coses que els bots em proposen, les rebutjo.
+
+Quan vaig veure aquesta xifra per primer cop la vaig llegir com un fracàs. Vaig trigar unes setmanes a entendre que és exactament al revés: **el 33% és el producte**. Un sistema que em proposés només coses bones seria un sistema que proposa molt poc. El que vull és un que proposi generosament i em deixi la decisió barata.
+
+Rebutjar un issue em costa cinc segons. Revertir un canvi fusionat que no calia em costa una tarda. Mentre aquesta asimetria existeixi, val la pena que el bot sigui una mica pesat.
+
+I val la pena mirar-s'ho al revés: **55 tasques que jo no he hagut de pensar**. No d'escriure — de *pensar*. La feina que m'estalvia aquest sistema no és teclejar, és la de mirar el projecte un dilluns al matí i decidir què toca fer.
+
+## En què són bons i en què no
+
+El patró és bastant clar després de cinc mesos.
+
+**Hi són bons**: accessibilitat (atributs que falten, contrastos, etiquetes de formulari), detalls de SEO, metadades, dependències amb vulnerabilitats conegudes, casos límit que no havia contemplat, i tota la feina avorreta i mecànica que jo aniria posposant indefinidament.
+
+**Hi són dolents**: prioritzar. Un bot no sap que aquesta web és el meu currículum i no un producte amb usuaris. Proposa infraestructura per a problemes que no tinc, optimitzacions per a un trànsit que no rebo i abstraccions per a codi que ningú més tocarà. No té criteri de producte perquè no sap què és aquest producte, i això no es soluciona amb un *prompt* millor.
+
+També són dolents jutjant si una cosa ja està feta. D'aquí ve la comprovació de duplicats que vaig haver d'afegir-hi.
+
+## Fiabilitat
+
+| Workflow | Execucions | Fallades |
+|---|---|---|
+| Improvement Proposer | 32 | 2 |
+| Code Quality Scanner | 51 | 4 |
+| Auto Fixer | 64 | 0 |
+
+El *fixer* no ha fallat mai en 64 execucions, cosa que em fa una mica de por perquè és el que té permisos d'escriptura.
+
+Hi ha un detall en aquesta taula que diu més del sistema que la resta de l'article: en cinc mesos hi ha hagut unes 22 setmanes, i per tant 22 dilluns. Però el *fixer* ha corregut **64 vegades**. Vol dir que la gran majoria d'execucions **les llanço jo a mà**, quan aprovo alguna cosa i no tinc ganes d'esperar-me al dilluns.
+
+El cron va acabar sent el mínim garantit, no el mecanisme principal. Si tornés a començar, potser ni el posaria.
+
+## La CI hi és per fallar
+
+De les últimes 100 execucions de la integració contínua, **25 han fallat**.
+
+Aquesta és, de totes les xifres de l'article, la que menys em preocupa. Una CI que no falla mai no t'està protegint de res: només t'està confirmant que ja ho feies bé. Un quart de fallades vol dir que hi ha quatre gates reals (tipus, *lint*, tests i *build*) i que de tant en tant fan la seva feina, tant amb el meu codi com amb el dels bots.
+
+## Ho tornaria a fer?
+
+Sí, però amb una expectativa diferent de la que tenia al març.
+
+Al març em pensava que estava construint una cosa que **mantindria la web sola**. El que he acabat tenint és una cosa que **em porta la feina ja pensada** i espera que jo decideixi. És menys espectacular d'explicar i molt més útil de tenir.
+
+La lliçó, si n'hi ha alguna, és que la part difícil d'automatitzar amb IA no és aconseguir que faci coses. És decidir **què no la deixes fer**. Tot el valor d'aquest sistema està en aquella etiqueta `approved` que només poso jo, i en el fet que cap bot pot fusionar res.
+
+Cinc mesos, 169 propostes, 55 sís i 114 nos. Els nos també són feina feta.

--- a/content/blog/ca/com-esta-feta-aquesta-web.mdx
+++ b/content/blog/ca/com-esta-feta-aquesta-web.mdx
@@ -1,0 +1,59 @@
+---
+title: "Com està feta aquesta web"
+date: "2026-08-08"
+description: "El stack, les decisions i els detalls petits que fan que tot encaixi"
+tags: ["web", "nextjs", "ia", "claude"]
+published: true
+---
+
+Fa uns mesos vaig publicar la primera versió d'aquesta web i vaig prometre que allò només era el principi. Han passat cinc mesos, i ara sí que hi ha alguna cosa a explicar. Aquest article és el primer de tres: aquí explico **com està feta la web**; al següent, els bots que la mantenen; i al tercer, els números reals de tot plegat.
+
+## El stack, sense sorpreses
+
+No hi ha res exòtic aquí, i és deliberat:
+
+* **[Next.js 16](https://nextjs.org)** amb l'App Router. Tot el que es pot generar estàticament, es genera estàticament.
+* **TypeScript** en mode estricte. No és negociable: si el compilador no hi està d'acord, no entra.
+* **[Tailwind CSS v4](https://tailwindcss.com)** amb variables de tema pròpies, que és el que permet que el mode fosc i clar siguin només un atribut `data-theme` a l'arrel.
+* **[Vercel](https://vercel.com)**, pla gratuït. Per a una web personal, sobra.
+
+La font és **JetBrains Mono** a tot arreu. És una decisió estètica discutible i no penso discutir-la.
+
+## El blog són fitxers, no una base de dades
+
+Els articles són fitxers **MDX** dins de `content/blog/`, amb frontmatter llegit amb `gray-matter`. Cap CMS, cap base de dades, cap panell d'administració. Escriure un article és crear un fitxer i fer *commit*.
+
+Això té una conseqüència agradable: el temps de lectura, les etiquetes, l'índex de continguts i el *feed* RSS surten tots de llegir els mateixos fitxers en temps de *build*. No hi ha res a sincronitzar perquè no hi ha dues fonts de veritat.
+
+## Tres idiomes sense duplicar feina
+
+La web està en **català, castellà i anglès**, gestionada amb `next-intl`. Els textos de la interfície viuen en tres fitxers JSON; els articles, en tres carpetes paral·leles.
+
+La part que m'agrada: escric l'article **només en català**, i després executo un script que el tradueix als altres dos idiomes cridant l'API de Claude. Manté el frontmatter, la data i les etiquetes intactes, i només toca el títol, la descripció i el cos:
+
+```bash
+pnpm run translate-post com-esta-feta-aquesta-web
+```
+
+No és perfecte i sempre hi faig una repassada, però la diferència entre "he d'escriure això tres vegades" i "he de revisar això dues vegades" és exactament la diferència entre publicar i no publicar.
+
+## Els detalls petits
+
+Són els que m'han donat més gust de fer:
+
+* La data d'**última actualització** de la pàgina */ara* i del peu no està escrita a mà enlloc: surt de preguntar-li al `git` quan es va tocar per última vegada el fitxer corresponent. És impossible que quedi desactualitzada perquè ningú l'actualitza.
+* Cada article genera la seva pròpia **imatge d'Open Graph**, així que quan es comparteix un enllaç, la previsualització és la bona.
+* Hi ha un **CV imprimible** a `/cv` que és la mateixa informació que la home, però amb estils de `print`. Un `Ctrl+P` i ja tens un PDF.
+* Barra de progrés de lectura, índex de continguts, cerca al llistat d'articles, botó de compartir, animacions d'aparició en fer *scroll*. Cap d'aquestes coses és imprescindible; totes juntes són el que fa que una web es noti cuidada.
+
+## El que passa abans de publicar
+
+Cada *push* i cada *pull request* dispara una acció de GitHub que fa quatre coses en ordre: comprovació de tipus, *lint*, tests amb Vitest i *build* completa. Si qualsevol falla, no es fusiona.
+
+Sona excessiu per a una web personal. Ho és, fins que deixes que uns bots hi facin canvis sols — i aquesta és exactament la història del pròxim article.
+
+## Què ve ara
+
+La web ja no és el projecte. La web és **el banc de proves** del projecte, que és una altra cosa: veure fins on pot arribar un sistema on la IA proposa la feina, la fa, i jo només decideixo què entra.
+
+Al pròxim article explico com funciona aquest sistema. A l'últim, què ha produït realment en cinc mesos, amb els números a la mà i sense endolcir-los.

--- a/content/blog/en/bots-que-proposen-jo-decideixo.mdx
+++ b/content/blog/en/bots-que-proposen-jo-decideixo.mdx
@@ -1,0 +1,63 @@
+---
+title: "Bots that propose, I decide"
+date: "2026-08-09"
+description: "How three GitHub Actions find work, do it, and why the brake is the important part"
+tags: ["automatitzacio", "github-actions", "ia", "claude"]
+published: true
+---
+
+In the first article on this website I wrote that I was designing "an automated system for improvements and GitHub Issue management." This exists, it's been running for five months, and this article explains how.
+
+Fair warning upfront: the interesting part isn't that the AI writes code. We all know that already. The interesting part is **where I put the brake**.
+
+## Three bots, a Monday morning
+
+It all happens while I'm having breakfast, chained one hour apart:
+
+| Time (UTC) | Who | What it does |
+|---|---|---|
+| 07:00 | Improvement Proposer | Reads the code and proposes up to **3 improvements** |
+| 08:00 | Code Quality Scanner | Looks for problems and opens up to **5 issues** |
+| 09:00 | Auto Fixer | Picks up approved work and opens a **pull request** |
+
+The first two only have permission to **open issues**. They can't touch the code even if they wanted to: in the *workflow* file, the contents permission is read-only. This isn't a matter of trust, it's a matter of design — a bot that can't write can't break anything.
+
+The **Improvement Proposer** looks at the project and suggests things that could be good for it: accessibility, performance, SEO, missing features. It labels the issues with `enhancement` and `automated`.
+
+The **Code Quality Scanner** does the opposite job: it looks for what's already there and is wrong. Labels: `bug` and `automated`.
+
+Both of them have something that turned out to be more important than I expected: **they check the issues that already exist** — open and closed — and compare the title words to avoid proposing the same thing again. Without this, every Monday I'd get the same five ideas. A bot with the memory of a goldfish is worse than no bot at all, because the weekly noise makes you stop reading it.
+
+## The label that changes everything
+
+This is where the system earns its keep. The **Auto Fixer** doesn't touch any issue unless it has **three labels**: `bug` or `enhancement`, plus `automated`, **plus `approved`**.
+
+And the `approved` label is only added by me, by hand.
+
+This means that every Monday at nine the *fixer* wakes up, checks if there's any work I've explicitly blessed, and if there isn't, it goes back to sleep. The system doesn't decide what's important. It proposes, and waits.
+
+On top of that, when it runs on its own, **it only processes one issue per execution**. It could do five. It doesn't do five because then I'd have to review five *pull requests*, and a human reviewing five PRs at once doesn't review: they approve.
+
+## What it actually does when it starts up
+
+When there's an approved issue, the *fixer* reads the issue, reads the relevant files, writes the change, creates a branch (`fix/...` or `feat/...`), makes the *commit*, and opens a *pull request* that references the original issue.
+
+And then it stops. It doesn't merge. **It never merges.**
+
+The two detection bots use **Claude Sonnet**, which is fast and cheap for reading a lot of code. The one that writes the changes uses **Claude Opus**, because writing correct code is worth paying for. Finding problems is easy; fixing them without breaking anything is not.
+
+## The final gate
+
+Every PR the bot opens goes through the same CI as mine: type checking, *lint*, tests, and *build*. If the bot has written something that doesn't compile, we know before I even read it.
+
+So the complete chain, from start to finish, is this:
+
+**The bot proposes → I approve → the bot writes it → CI verifies it → I merge it.**
+
+There are exactly two points where there's a human, and both are decisions, not work. That's the whole idea. I didn't want a system that worked for me while I sleep; I wanted a system that **brought me the work already thought through** so I'd only have to say yes or no.
+
+## What nobody talks about
+
+A system like this looks much more impressive in a diagram than in practice. The bots propose obvious things, unnecessary things, and, every now and then, something I hadn't thought of that's genuinely good. The ratio between these three categories is the metric that truly matters.
+
+I have five months of data on exactly this, and I'll cover it in the next article. The short conclusion: **I reject most of their ideas**, and that's precisely why the system works.

--- a/content/blog/en/cinc-mesos-de-bots-els-numeros.mdx
+++ b/content/blog/en/cinc-mesos-de-bots-els-numeros.mdx
@@ -1,0 +1,69 @@
+---
+title: "Five months of bots: the numbers"
+date: "2026-08-10"
+description: "169 issues, 53 merged pull requests, and what I learned from rejecting two thirds of the proposals"
+tags: ["automatitzacio", "dades", "retrospectiva", "claude"]
+published: true
+---
+
+In the two previous articles I explained how this website is built and how the bots that maintain it work. This is the one I actually wanted to write: **what all of this has produced**, with the real numbers from the repository and without sugarcoating them.
+
+Period: from March 9 to August 10, 2026. Five months exactly.
+
+## The numbers
+
+**169 issues** opened automatically. Split almost evenly: **83 bugs** and **86 improvement proposals**. A symmetry I didn't plan and that surprised me.
+
+Of those 169, I approved **55**. That is, **33%**.
+
+**53 pull requests merged**, with **+5,238 lines added and −1,501 removed**.
+
+## The number that matters is 33%
+
+Two out of every three things the bots propose to me, I reject.
+
+When I first saw this figure I read it as a failure. It took me a few weeks to understand it's exactly the opposite: **the 33% is the product**. A system that only proposed good things would be a system that proposes very little. What I want is one that proposes generously and leaves the decision cheap for me.
+
+Rejecting an issue costs me five seconds. Reverting a merged change that wasn't needed costs me an afternoon. As long as this asymmetry exists, it's worth it for the bot to be a little pushy.
+
+And it's worth looking at it the other way around: **55 tasks I didn't have to think of**. Not write — *think of*. The work this system saves me isn't typing, it's looking at the project on a Monday morning and deciding what needs doing.
+
+## What they're good at and what they're not
+
+The pattern is fairly clear after five months.
+
+**They're good at**: accessibility (missing attributes, contrasts, form labels), SEO details, metadata, dependencies with known vulnerabilities, edge cases I hadn't considered, and all the boring, mechanical work I'd keep postponing indefinitely.
+
+**They're bad at**: prioritizing. A bot doesn't know that this website is my résumé and not a product with users. It proposes infrastructure for problems I don't have, optimizations for traffic I don't receive, and abstractions for code nobody else will touch. It has no product judgment because it doesn't know what this product is, and that can't be fixed with a better *prompt*.
+
+They're also bad at judging whether something is already done. That's where the duplicate check I had to add came from.
+
+## Reliability
+
+| Workflow | Runs | Failures |
+|---|---|---|
+| Improvement Proposer | 32 | 2 |
+| Code Quality Scanner | 51 | 4 |
+| Auto Fixer | 64 | 0 |
+
+The *fixer* has never failed in 64 runs, which scares me a little because it's the one with write permissions.
+
+There's a detail in this table that says more about the system than the rest of the article: in five months there have been about 22 weeks, and therefore 22 Mondays. But the *fixer* has run **64 times**. That means the vast majority of runs **I trigger manually**, when I approve something and don't feel like waiting until Monday.
+
+The cron ended up being the guaranteed minimum, not the main mechanism. If I started over, I might not even include it.
+
+## CI is there to fail
+
+Of the last 100 continuous integration runs, **25 failed**.
+
+This is, of all the figures in this article, the one that worries me least. A CI that never fails isn't protecting you from anything: it's only confirming you were already doing it right. A quarter of failures means there are four real gates (types, *lint*, tests, and *build*) and that from time to time they do their job, both with my code and with the bots' code.
+
+## Would I do it again?
+
+Yes, but with a different expectation from the one I had in March.
+
+In March I thought I was building something that **would maintain the website on its own**. What I ended up having is something that **brings me the work already thought through** and waits for me to decide. It's less spectacular to explain and much more useful to have.
+
+The lesson, if there is one, is that the hard part of automating with AI isn't getting it to do things. It's deciding **what you don't let it do**. All the value of this system lies in that `approved` label that only I apply, and in the fact that no bot can merge anything.
+
+Five months, 169 proposals, 55 yeses and 114 nos. The nos are work done too.

--- a/content/blog/en/com-esta-feta-aquesta-web.mdx
+++ b/content/blog/en/com-esta-feta-aquesta-web.mdx
@@ -1,0 +1,59 @@
+---
+title: "How this website is made"
+date: "2026-08-08"
+description: "The stack, the decisions, and the small details that make everything fit together"
+tags: ["web", "nextjs", "ia", "claude"]
+published: true
+---
+
+A few months ago I published the first version of this website and promised that it was only the beginning. Five months have passed, and now there is actually something to explain. This article is the first of three: here I explain **how the website is made**; in the next one, the bots that maintain it; and in the third, the real numbers of the whole thing.
+
+## The stack, no surprises
+
+There's nothing exotic here, and it's deliberate:
+
+* **[Next.js 16](https://nextjs.org)** with the App Router. Everything that can be statically generated is statically generated.
+* **TypeScript** in strict mode. It's non-negotiable: if the compiler doesn't agree, it doesn't get in.
+* **[Tailwind CSS v4](https://tailwindcss.com)** with custom theme variables, which is what allows dark and light mode to be just a `data-theme` attribute on the root.
+* **[Vercel](https://vercel.com)**, free plan. For a personal website, it's more than enough.
+
+The font is **JetBrains Mono** everywhere. It's a debatable aesthetic decision and I don't intend to debate it.
+
+## The blog is files, not a database
+
+The articles are **MDX** files inside `content/blog/`, with frontmatter read using `gray-matter`. No CMS, no database, no admin panel. Writing an article is creating a file and making a *commit*.
+
+This has a pleasant consequence: the reading time, tags, table of contents, and RSS *feed* all come from reading the same files at *build* time. There's nothing to synchronize because there aren't two sources of truth.
+
+## Three languages without duplicating work
+
+The website is in **Catalan, Spanish, and English**, managed with `next-intl`. The interface texts live in three JSON files; the articles, in three parallel folders.
+
+The part I like: I write the article **only in Catalan**, and then I run a script that translates it to the other two languages by calling Claude's API. It keeps the frontmatter, date, and tags intact, and only touches the title, description, and body:
+
+```bash
+pnpm run translate-post com-esta-feta-aquesta-web
+```
+
+It's not perfect and I always do a review pass, but the difference between "I have to write this three times" and "I have to review this twice" is exactly the difference between publishing and not publishing.
+
+## The small details
+
+These are the ones I enjoyed making the most:
+
+* The **last updated** date on the */now* page and the footer isn't written by hand anywhere: it comes from asking `git` when the corresponding file was last touched. It's impossible for it to become outdated because nobody updates it.
+* Each article generates its own **Open Graph image**, so when a link is shared, the preview is the right one.
+* There's a **printable CV** at `/cv` that is the same information as the home page, but with `print` styles. A `Ctrl+P` and you've got a PDF.
+* Reading progress bar, table of contents, search in the article list, share button, scroll-triggered appearance animations. None of these things is essential; all of them together are what makes a website feel polished.
+
+## What happens before publishing
+
+Every *push* and every *pull request* triggers a GitHub action that does four things in order: type checking, *lint*, tests with Vitest, and a full *build*. If any of them fails, it doesn't get merged.
+
+It sounds excessive for a personal website. It is, until you let bots make changes on their own — and that's exactly the story of the next article.
+
+## What comes next
+
+The website is no longer the project. The website is **the testing ground** for the project, which is something else: seeing how far a system can go where AI proposes the work, does it, and I only decide what gets in.
+
+In the next article I explain how this system works. In the last one, what it has actually produced in five months, with the numbers in hand and without sugarcoating them.

--- a/content/blog/es/bots-que-proposen-jo-decideixo.mdx
+++ b/content/blog/es/bots-que-proposen-jo-decideixo.mdx
@@ -1,0 +1,63 @@
+---
+title: "Bots que proponen, yo decido"
+date: "2026-08-09"
+description: "Cómo tres acciones de GitHub encuentran trabajo, lo hacen, y por qué el freno es la parte importante"
+tags: ["automatitzacio", "github-actions", "ia", "claude"]
+published: true
+---
+
+En el primer artículo de esta web escribí que estaba diseñando "un sistema automatizado de mejoras y gestión de Issues en GitHub". Eso existe, lleva cinco meses funcionando, y este artículo explica cómo.
+
+Aviso de entrada: la parte interesante no es que la IA escriba código. Eso ya lo sabemos todos. La parte interesante es **dónde le puse el freno**.
+
+## Tres bots, un lunes por la mañana
+
+Todo pasa mientras desayuno, encadenado con una hora de diferencia:
+
+| Hora (UTC) | Quién | Qué hace |
+|---|---|---|
+| 07:00 | Improvement Proposer | Lee el código y propone hasta **3 mejoras** |
+| 08:00 | Code Quality Scanner | Busca problemas y abre hasta **5 issues** |
+| 09:00 | Auto Fixer | Coge trabajo aprobado y abre un **pull request** |
+
+Los dos primeros solo tienen permiso para **abrir issues**. No pueden tocar el código ni aunque quieran: en el fichero del *workflow*, el permiso de contenidos es de solo lectura. Esto no es una cuestión de confianza, es una cuestión de diseño — un bot que no puede escribir no puede romper nada.
+
+El **Improvement Proposer** mira el proyecto y sugiere cosas que podrían ir bien: accesibilidad, rendimiento, SEO, funcionalidades que faltan. Etiqueta los issues con `enhancement` y `automated`.
+
+El **Code Quality Scanner** hace el trabajo contrario: busca lo que ya está y está mal. Etiquetas `bug` y `automated`.
+
+Ambos tienen algo que resultó más importante de lo que esperaba: **comprueban los issues que ya existen** — abiertos y cerrados — y comparan las palabras del título para no volver a proponer lo mismo. Sin esto, cada lunes recibía las mismas cinco ideas. Un bot con memoria de pez es peor que ningún bot, porque el ruido semanal hace que dejes de leerlo.
+
+## La etiqueta que lo cambia todo
+
+Aquí es donde el sistema se gana el sueldo. El **Auto Fixer** no toca ningún issue a menos que tenga **tres etiquetas**: `bug` o `enhancement`, más `automated`, **más `approved`**.
+
+Y la etiqueta `approved` solo la pongo yo, a mano.
+
+Significa que cada lunes a las nueve el *fixer* se despierta, mira si hay trabajo que yo haya bendecido explícitamente, y si no lo hay, se vuelve a dormir. El sistema no decide qué es importante. Propone, y espera.
+
+Encima, cuando corre solo, **solo procesa un issue por ejecución**. Podría hacer cinco. No hace cinco porque después yo tengo que revisar cinco *pull requests*, y un humano revisando cinco PRs de golpe no revisa: aprueba.
+
+## Qué hace exactamente cuando arranca
+
+Cuando hay un issue aprobado, el *fixer* lee el issue, lee los ficheros implicados, escribe el cambio, crea una rama (`fix/...` o `feat/...`), hace el *commit* y abre un *pull request* que referencia el issue original.
+
+Y entonces se detiene. No fusiona. **Nunca fusiona.**
+
+Los dos bots de detección usan **Claude Sonnet**, que es rápido y barato para leer mucho código. El que escribe los cambios usa **Claude Opus**, porque escribir código correcto vale la pena pagarlo. Encontrar problemas es fácil; arreglarlos sin romper nada, no.
+
+## La última puerta
+
+Cada PR que abre el bot pasa por la misma CI que los míos: comprobación de tipos, *lint*, tests y *build*. Si el bot ha escrito algo que no compila, lo sabemos antes de que yo lo lea.
+
+Así que la cadena completa, de principio a fin, es esta:
+
+**El bot propone → yo apruebo → el bot lo escribe → la CI lo verifica → yo lo fusiono.**
+
+Hay exactamente dos puntos donde hay un humano, y ambos son decisiones, no trabajo. Esa es toda la idea. No quería un sistema que trabajase por mí mientras duermo; quería un sistema que **me trajese el trabajo ya pensado** para que yo solo tuviese que decir que sí o que no.
+
+## Lo que no explica nadie
+
+Un sistema así parece mucho más impresionante en un diagrama que en la práctica. Los bots proponen cosas obvias, cosas innecesarias y, de vez en cuando, alguna cosa que no se me había ocurrido y que es buena de verdad. La proporción entre estas tres categorías es la métrica que realmente importa.
+
+Tengo cinco meses de datos sobre exactamente esto, y los explico en el próximo artículo. La conclusión corta: **la mayoría de sus ideas las rechazo**, y es precisamente por eso que el sistema funciona.

--- a/content/blog/es/cinc-mesos-de-bots-els-numeros.mdx
+++ b/content/blog/es/cinc-mesos-de-bots-els-numeros.mdx
@@ -1,0 +1,69 @@
+---
+title: "Cinco meses de bots: los números"
+date: "2026-08-10"
+description: "169 issues, 53 pull requests fusionados y qué he aprendido rechazando dos tercios de las propuestas"
+tags: ["automatitzacio", "dades", "retrospectiva", "claude"]
+published: true
+---
+
+En los dos artículos anteriores he explicado cómo está hecha esta web y cómo funcionan los bots que la mantienen. Este es el que realmente quería escribir: **qué ha producido todo esto**, con las cifras reales del repositorio y sin endulzarlas.
+
+Período: del 9 de marzo al 10 de agosto de 2026. Cinco meses justos.
+
+## Las cifras
+
+**169 issues** abiertos automáticamente. Repartidos casi a partes iguales: **83 errores** y **86 propuestas de mejora**. Una simetría que no planifiqué y que me sorprendió.
+
+De esos 169, he aprobado **55**. Es decir, **un 33%**.
+
+**53 pull requests fusionados**, con **+5.238 líneas añadidas y −1.501 eliminadas**.
+
+## El número que importa es el 33%
+
+Dos de cada tres cosas que los bots me proponen, las rechazo.
+
+Cuando vi esta cifra por primera vez la leí como un fracaso. Tardé unas semanas en entender que es exactamente al revés: **el 33% es el producto**. Un sistema que me propusiera solo cosas buenas sería un sistema que propone muy poco. Lo que quiero es uno que proponga generosamente y me deje la decisión barata.
+
+Rechazar un issue me cuesta cinco segundos. Revertir un cambio fusionado que no hacía falta me cuesta una tarde. Mientras esta asimetría exista, vale la pena que el bot sea un poco pesado.
+
+Y vale la pena mirárselo al revés: **55 tareas que yo no he tenido que pensar**. No escribir — *pensar*. El trabajo que me ahorra este sistema no es teclear, es el de mirar el proyecto un lunes por la mañana y decidir qué toca hacer.
+
+## En qué son buenos y en qué no
+
+El patrón es bastante claro después de cinco meses.
+
+**Son buenos en**: accesibilidad (atributos que faltan, contrastes, etiquetas de formulario), detalles de SEO, metadatos, dependencias con vulnerabilidades conocidas, casos límite que no había contemplado, y todo el trabajo aburrido y mecánico que yo iría posponiendo indefinidamente.
+
+**Son malos en**: priorizar. Un bot no sabe que esta web es mi currículum y no un producto con usuarios. Propone infraestructura para problemas que no tengo, optimizaciones para un tráfico que no recibo y abstracciones para código que nadie más tocará. No tiene criterio de producto porque no sabe qué es este producto, y eso no se soluciona con un *prompt* mejor.
+
+También son malos juzgando si algo ya está hecho. De ahí viene la comprobación de duplicados que tuve que añadir.
+
+## Fiabilidad
+
+| Workflow | Ejecuciones | Fallos |
+|---|---|---|
+| Improvement Proposer | 32 | 2 |
+| Code Quality Scanner | 51 | 4 |
+| Auto Fixer | 64 | 0 |
+
+El *fixer* no ha fallado nunca en 64 ejecuciones, cosa que me da un poco de miedo porque es el que tiene permisos de escritura.
+
+Hay un detalle en esta tabla que dice más del sistema que el resto del artículo: en cinco meses ha habido unas 22 semanas, y por tanto 22 lunes. Pero el *fixer* ha corrido **64 veces**. Significa que la gran mayoría de ejecuciones **las lanzo yo a mano**, cuando apruebo algo y no tengo ganas de esperarme al lunes.
+
+El cron acabó siendo el mínimo garantizado, no el mecanismo principal. Si volviera a empezar, quizá ni lo pondría.
+
+## La CI está para fallar
+
+De las últimas 100 ejecuciones de la integración continua, **25 han fallado**.
+
+Esta es, de todas las cifras del artículo, la que menos me preocupa. Una CI que no falla nunca no te está protegiendo de nada: solo te está confirmando que ya lo hacías bien. Un cuarto de fallos significa que hay cuatro gates reales (tipos, *lint*, tests y *build*) y que de vez en cuando hacen su trabajo, tanto con mi código como con el de los bots.
+
+## ¿Lo volvería a hacer?
+
+Sí, pero con una expectativa diferente de la que tenía en marzo.
+
+En marzo me pensaba que estaba construyendo algo que **mantendría la web sola**. Lo que he acabado teniendo es algo que **me trae el trabajo ya pensado** y espera que yo decida. Es menos espectacular de explicar y mucho más útil de tener.
+
+La lección, si hay alguna, es que la parte difícil de automatizar con IA no es conseguir que haga cosas. Es decidir **qué no la dejas hacer**. Todo el valor de este sistema está en aquella etiqueta `approved` que solo pongo yo, y en el hecho de que ningún bot puede fusionar nada.
+
+Cinco meses, 169 propuestas, 55 síes y 114 noes. Los noes también son trabajo hecho.

--- a/content/blog/es/com-esta-feta-aquesta-web.mdx
+++ b/content/blog/es/com-esta-feta-aquesta-web.mdx
@@ -1,0 +1,59 @@
+---
+title: "Cómo está hecha esta web"
+date: "2026-08-08"
+description: "El stack, las decisiones y los pequeños detalles que hacen que todo encaje"
+tags: ["web", "nextjs", "ia", "claude"]
+published: true
+---
+
+Hace unos meses publiqué la primera versión de esta web y prometí que aquello solo era el principio. Han pasado cinco meses, y ahora sí que hay algo que explicar. Este artículo es el primero de tres: aquí explico **cómo está hecha la web**; en el siguiente, los bots que la mantienen; y en el tercero, los números reales de todo el conjunto.
+
+## El stack, sin sorpresas
+
+No hay nada exótico aquí, y es deliberado:
+
+* **[Next.js 16](https://nextjs.org)** con el App Router. Todo lo que se puede generar estáticamente, se genera estáticamente.
+* **TypeScript** en modo estricto. No es negociable: si el compilador no está de acuerdo, no entra.
+* **[Tailwind CSS v4](https://tailwindcss.com)** con variables de tema propias, que es lo que permite que el modo oscuro y claro sean solo un atributo `data-theme` en la raíz.
+* **[Vercel](https://vercel.com)**, plan gratuito. Para una web personal, sobra.
+
+La fuente es **JetBrains Mono** en todas partes. Es una decisión estética discutible y no pienso discutirla.
+
+## El blog son ficheros, no una base de datos
+
+Los artículos son ficheros **MDX** dentro de `content/blog/`, con frontmatter leído con `gray-matter`. Ningún CMS, ninguna base de datos, ningún panel de administración. Escribir un artículo es crear un fichero y hacer *commit*.
+
+Esto tiene una consecuencia agradable: el tiempo de lectura, las etiquetas, el índice de contenidos y el *feed* RSS salen todos de leer los mismos ficheros en tiempo de *build*. No hay nada que sincronizar porque no hay dos fuentes de verdad.
+
+## Tres idiomas sin duplicar trabajo
+
+La web está en **catalán, castellano e inglés**, gestionada con `next-intl`. Los textos de la interfaz viven en tres ficheros JSON; los artículos, en tres carpetas paralelas.
+
+La parte que me gusta: escribo el artículo **solo en catalán**, y después ejecuto un script que lo traduce a los otros dos idiomas llamando a la API de Claude. Mantiene el frontmatter, la fecha y las etiquetas intactas, y solo toca el título, la descripción y el cuerpo:
+
+```bash
+pnpm run translate-post com-esta-feta-aquesta-web
+```
+
+No es perfecto y siempre le echo un repaso, pero la diferencia entre "tengo que escribir esto tres veces" y "tengo que revisar esto dos veces" es exactamente la diferencia entre publicar y no publicar.
+
+## Los pequeños detalles
+
+Son los que más me han gustado hacer:
+
+* La fecha de **última actualización** de la página */ahora* y del pie no está escrita a mano en ningún sitio: sale de preguntarle al `git` cuándo se tocó por última vez el fichero correspondiente. Es imposible que quede desactualizada porque nadie la actualiza.
+* Cada artículo genera su propia **imagen de Open Graph**, así que cuando se comparte un enlace, la previsualización es la correcta.
+* Hay un **CV imprimible** en `/cv` que es la misma información que la home, pero con estilos de `print`. Un `Ctrl+P` y ya tienes un PDF.
+* Barra de progreso de lectura, índice de contenidos, búsqueda en el listado de artículos, botón de compartir, animaciones de aparición al hacer *scroll*. Ninguna de estas cosas es imprescindible; todas juntas son lo que hace que una web se note cuidada.
+
+## Lo que pasa antes de publicar
+
+Cada *push* y cada *pull request* dispara una acción de GitHub que hace cuatro cosas en orden: comprobación de tipos, *lint*, tests con Vitest y *build* completa. Si cualquiera falla, no se fusiona.
+
+Suena excesivo para una web personal. Lo es, hasta que dejas que unos bots hagan cambios solos — y esa es exactamente la historia del próximo artículo.
+
+## Qué viene ahora
+
+La web ya no es el proyecto. La web es **el banco de pruebas** del proyecto, que es otra cosa: ver hasta dónde puede llegar un sistema en el que la IA propone el trabajo, lo hace, y yo solo decido qué entra.
+
+En el próximo artículo explico cómo funciona ese sistema. En el último, qué ha producido realmente en cinco meses, con los números en la mano y sin endulzarlos.

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -8,7 +8,6 @@ import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import ThemeToggle from "@/components/ThemeToggle";
 import ScrollToTop from "@/components/ScrollToTop";
-import AvailabilityBanner from "@/components/AvailabilityBanner";
 import PageTransition from "@/components/PageTransition";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
@@ -138,7 +137,6 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
               {t("skipToContent")}
             </a>
             <Navbar />
-            <AvailabilityBanner />
             <main id="main-content" className="flex-1">
               <PageTransition>{children}</PageTransition>
             </main>

--- a/src/i18n/messages/ca.json
+++ b/src/i18n/messages/ca.json
@@ -404,18 +404,20 @@
     "heading": "Què faig ara",
     "lastUpdated": "Última actualització: {date}",
     "location": "Visc a <strong>Sant Pere de Vilamajor</strong>, a la part baixa del <strong>Montseny</strong>.",
-    "occupation": "Sóc <code>programador web front-end</code> i actualment cerco feina.",
-    "prioritiesHeading": "Les meves prioritats i el estat de projectes",
+    "occupation": "Sóc <code>programador web front-end</code> i actualment treballo en una empresa de producte del sector salut.",
+    "prioritiesHeading": "Les meves prioritats i l'estat dels projectes",
     "priorities": [
-      "Per capricis personals i decisions \"estratègiques\" l'empresa on treballava s'ha dissolt i em quedo a l'atur, això sí, només tinc agraïments cap a l'empresa on he estat aquests gairebé 8 anys.",
-      "Tocarà arrencar amb força la web amb <strong>Nuxt</strong> que tenia en stand-by.",
-      "A l''<strong>Sven</strong> li hem fet una neteja dental i li han tret un queixal (seny no n''ha tingut mai).",
-      "Hem tingut una mica de drama amb unes filtracions aquest mes de pluges, però ja està tot controlat."
+      "Des de l'última vegada que vaig actualitzar aquesta pàgina he passat per <strong>tres feines</strong>. La primera, una empresa de producte capdavantera del sector mecànic, em va acomiadar en període de prova als quatre mesos i sense cap mena d'explicació. La segona, una gran consultora, amb un client caòtic i un sou per sota del que tocava. La tercera és on sóc ara: una empresa de producte del <strong>sector salut</strong>, i aquí m'hi quedo.",
+      "Aquesta web ja no la mantinc sol. Tres accions de GitHub proposen millores i detecten errors cada dilluns, i jo decideixo què hi entra. En cinc mesos: <strong>169 propostes, 55 aprovades i 53 pull requests fusionats</strong>. Acabo de publicar una sèrie de tres articles explicant com funciona tot plegat.",
+      "Un SSD que va petar em va obligar a replantejar el servidor de casa: he abandonat Proxmox i ara tinc <strong>Home Assistant</strong> instal·lat directament sobre el maquinari. Estic aprenent molt per aquest camí, sovint a la força.",
+      "En <strong>Sven</strong> continua fent de les seves, que és exactament el que li demanem."
     ],
     "excitementHeading": "Què m'engresca",
     "excitement": [
-      "Ja estic a la recta final del llibre que vaig començar! M'està agradant i segurament continuaré amb la saga del <strong>Arxiu de les Tempestes</strong>.",
-      "Els bonsais estàn començant a brotar amb força, ara ve una època bonica de <strong>poda, transplantaments i formació</strong>."
+      "D'aquí a un parell de dies vaig a veure l''<strong>eclipsi total de sol</strong> en directe. Fa setmanes que no penso en gaire cosa més.",
+      "Un amic australià ens ve a veure, i ja estem començant a planificar un viatge per a l'any que ve.",
+      "Continuo amb la saga de l''<strong>Arxiu de les Tempestes</strong>.",
+      "Els bonsais ja han passat l'època de poda i transplantaments; ara toca la part menys lluïda i més important: <strong>reg, ombra i paciència</strong> fins que passi la calor."
     ],
     "nowPageDescription": "Aquesta és una <link>pàgina /ara</link>, inspirada en el moviment de Derek Sivers.",
     "footer": "Aquesta és la meva pàgina \"ara\" inspirada en el moviment <link>now page</link>."
@@ -445,6 +447,7 @@
   },
   "cv": {
     "title": "CV — Pau Bartrina",
+    "summaryHeading": "Resum",
     "description": "CV imprimible de Pau Bartrina, Senior Frontend Engineer.",
     "printButton": "Imprimir / Desar com a PDF",
     "backHome": "Tornar a l'inici"

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -404,18 +404,20 @@
     "heading": "What I'm doing now",
     "lastUpdated": "Last updated: {date}",
     "location": "I live in <strong>Sant Pere de Vilamajor</strong>, at the foot of <strong>Montseny</strong>.",
-    "occupation": "I'm a <code>front-end web developer</code> and currently looking for work.",
+    "occupation": "I'm a <code>front-end web developer</code> and I currently work at a product company in the health sector.",
     "prioritiesHeading": "My priorities and project status",
     "priorities": [
-      "Due to personal whims and \"strategic\" decisions, the company I was working at has dissolved and I'm now unemployed — that said, I only have gratitude towards the company where I spent nearly 8 years.",
-      "Time to get going with the website built with <strong>Nuxt</strong> that I had on stand-by.",
-      "<strong>Sven</strong> had a dental cleaning and they pulled one of his teeth (he was never the wise type).",
-      "We had a bit of drama with some water leaks this rainy month, but everything is under control now."
+      "Since I last updated this page I've been through <strong>three jobs</strong>. The first, a leading product company in the mechanical sector, let me go during my probation period after four months, with no explanation whatsoever. The second, a huge consultancy, with a chaotic client and a salary below what the work was worth. The third is where I am now: a product company in the <strong>health sector</strong>, and this is where I'm staying.",
+      "I no longer maintain this site on my own. Three GitHub Actions propose improvements and detect bugs every Monday, and I decide what gets in. Five months in: <strong>169 proposals, 55 approved and 53 merged pull requests</strong>. I've just published a three-part series explaining how it all works.",
+      "A blown SSD forced me to rethink the home server: I've ditched Proxmox and now run <strong>Home Assistant</strong> bare metal. I'm learning a lot down that path, often the hard way.",
+      "<strong>Sven</strong> is still up to his usual tricks, which is exactly what we ask of him."
     ],
     "excitementHeading": "What excites me",
     "excitement": [
-      "I'm on the home stretch of the book I started! I'm really enjoying it and will probably continue with the <strong>Stormlight Archive</strong> saga.",
-      "The bonsai trees are starting to sprout vigorously — now comes a beautiful season of <strong>pruning, repotting, and training</strong>."
+      "In a couple of days I'm going to see the <strong>total solar eclipse</strong> live. I haven't thought about much else for weeks.",
+      "An Australian friend is coming to visit, and we're already starting to plan a trip for next year.",
+      "I'm continuing with the <strong>Stormlight Archive</strong> saga.",
+      "The bonsai trees are past pruning and repotting season; now comes the least glamorous and most important part: <strong>watering, shade and patience</strong> until the heat passes."
     ],
     "nowPageDescription": "This is a <link>/now page</link>, inspired by Derek Sivers' movement.",
     "footer": "This is my \"now\" page inspired by the <link>now page</link> movement."
@@ -445,6 +447,7 @@
   },
   "cv": {
     "title": "CV — Pau Bartrina",
+    "summaryHeading": "Summary",
     "description": "Printable CV for Pau Bartrina, Senior Frontend Engineer.",
     "printButton": "Print / Save as PDF",
     "backHome": "Back to home"

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -404,18 +404,20 @@
     "heading": "Qué hago ahora",
     "lastUpdated": "Última actualización: {date}",
     "location": "Vivo en <strong>Sant Pere de Vilamajor</strong>, en la parte baja del <strong>Montseny</strong>.",
-    "occupation": "Soy <code>programador web front-end</code> y actualmente busco trabajo.",
-    "prioritiesHeading": "Mis prioridades y el estado de proyectos",
+    "occupation": "Soy <code>programador web front-end</code> y actualmente trabajo en una empresa de producto del sector salud.",
+    "prioritiesHeading": "Mis prioridades y el estado de los proyectos",
     "priorities": [
-      "Por caprichos personales y decisiones \"estratégicas\" la empresa donde trabajaba se ha disuelto y me quedo en paro, eso sí, solo tengo agradecimientos hacia la empresa donde he estado estos casi 8 años.",
-      "Tocará arrancar con fuerza la web con <strong>Nuxt</strong> que tenía en stand-by.",
-      "Al <strong>Sven</strong> le hemos hecho una limpieza dental y le han sacado una muela (juicio no ha tenido nunca).",
-      "Hemos tenido un poco de drama con unas filtraciones este mes de lluvias, pero ya está todo controlado."
+      "Desde la última vez que actualicé esta página he pasado por <strong>tres trabajos</strong>. El primero, una empresa de producto puntera del sector mecánico, me despidió en periodo de prueba a los cuatro meses y sin ningún tipo de explicación. El segundo, una gran consultora, con un cliente caótico y un sueldo por debajo de lo que tocaba. El tercero es donde estoy ahora: una empresa de producto del <strong>sector salud</strong>, y aquí me quedo.",
+      "Esta web ya no la mantengo solo. Tres acciones de GitHub proponen mejoras y detectan errores cada lunes, y yo decido qué entra. En cinco meses: <strong>169 propuestas, 55 aprobadas y 53 pull requests fusionados</strong>. Acabo de publicar una serie de tres artículos explicando cómo funciona todo.",
+      "Un SSD que reventó me obligó a replantear el servidor de casa: he abandonado Proxmox y ahora tengo <strong>Home Assistant</strong> instalado directamente sobre el hardware. Estoy aprendiendo mucho por ese camino, a menudo a la fuerza.",
+      "<strong>Sven</strong> sigue haciendo de las suyas, que es exactamente lo que le pedimos."
     ],
     "excitementHeading": "Qué me entusiasma",
     "excitement": [
-      "¡Ya estoy en la recta final del libro que empecé! Me está gustando y seguramente continuaré con la saga del <strong>Archivo de las Tormentas</strong>.",
-      "Los bonsáis están empezando a brotar con fuerza, ahora viene una época bonita de <strong>poda, trasplantes y formación</strong>."
+      "Dentro de un par de días voy a ver el <strong>eclipse total de sol</strong> en directo. Hace semanas que no pienso en mucho más.",
+      "Un amigo australiano viene a vernos, y ya estamos empezando a planificar un viaje para el año que viene.",
+      "Sigo con la saga del <strong>Archivo de las Tormentas</strong>.",
+      "Los bonsáis ya han pasado la época de poda y trasplantes; ahora toca la parte menos lucida y más importante: <strong>riego, sombra y paciencia</strong> hasta que pase el calor."
     ],
     "nowPageDescription": "Esta es una <link>página /ahora</link>, inspirada en el movimiento de Derek Sivers.",
     "footer": "Esta es mi página \"ahora\" inspirada en el movimiento <link>now page</link>."
@@ -445,6 +447,7 @@
   },
   "cv": {
     "title": "CV — Pau Bartrina",
+    "summaryHeading": "Resumen",
     "description": "CV imprimible de Pau Bartrina, Senior Frontend Engineer.",
     "printButton": "Imprimir / Guardar como PDF",
     "backHome": "Volver al inicio"


### PR DESCRIPTION
## Blog series (3 posts × 3 locales)

Written in Catalan, translated with `scripts/translate-post.ts`:

| Date | Slug | What it covers |
|---|---|---|
| Aug 8 | `com-esta-feta-aquesta-web` | Stack tour: Next.js 16, MDX-as-files, next-intl, git-derived "last updated", printable CV |
| Aug 9 | `bots-que-proposen-jo-decideixo` | The Monday 07:00/08:00/09:00 cascade and the `approved` label as the human gate |
| Aug 10 | `cinc-mesos-de-bots-els-numeros` | Five-month retrospective from real repo data |

The series follows up on the promise at the end of "Pla i primera versió".

Post 3's figures come from `gh` rather than estimates: 169 automated issues (83 bug / 86 enhancement), 55 approved (33%), 53 merged PRs, +5,238/−1,501 lines; workflow reliability 30/32, 47/51, 64/64, and 25 of the last 100 CI runs failed.

Dates are spaced a day apart because `getAllPosts` sorts on date alone — identical dates would order the series arbitrarily.

## /now page

Full rewrite in all three locales. It still described March. Now covers the three job changes since (sectors only, no company names), the automation pipeline, the move from Proxmox to bare-metal Home Assistant after the SSD failure, and current personal threads.

`<AvailabilityBanner />` removed from the locale layout now that the job search is over. The component and its translations stay in place, so restoring it is a one-line change.

## Drive-by fix

`cv/page.tsx:101` renders `t("summaryHeading")` but no locale defined `cv.summaryHeading` — the printable CV was showing the literal string `cv.summaryHeading` as a section heading. Added Resum / Resumen / Summary.

## Gotcha worth knowing

In ICU message syntax an apostrophe before `<` opens an escape, so Catalan elisions like `l'<strong>` render the tag as visible text. Must be written `l''<strong>`. This bit the first draft of the /now page and is why `ca.json` has doubled apostrophes in two places.

## Verification

`tsc --noEmit`, `lint`, 168 tests and `build` all pass on this base. Checked in a browser against the dev server: all 10 `<strong>` tags render as real markup, all three locales list the series in order, the markdown tables in posts 2 and 3 render as tables, the banner is gone from every locale, and no missing-key text leaks on `/cv`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)