### PR TITLE
Retitle: Frontend Engineer → Senior Software Engineer

### DIFF
--- a/src/app/[locale]/ara/page.tsx
+++ b/src/app/[locale]/ara/page.tsx
@@ -45,7 +45,7 @@ export async function generateMetadata({
           url: ogImageUrl,
           width: 1200,
           height: 630,
-          alt: "Pau Bartrina – Senior Frontend Engineer",
+          alt: "Pau Bartrina – Senior Software Engineer",
         },
       ],
     },

--- a/src/app/[locale]/blog/feed.xml/route.ts
+++ b/src/app/[locale]/blog/feed.xml/route.ts
@@ -44,7 +44,7 @@ export async function GET(
   <channel>
     <title>Pau Bartrina – Blog</title>
     <link>${base}/${locale}/blog</link>
-    <description>Blog de Pau Bartrina - Senior Frontend Engineer</description>
+    <description>Blog de Pau Bartrina - Senior Software Engineer</description>
     <language>${locale}</language>
     <atom:link href="${base}/${locale}/blog/feed.xml" rel="self" type="application/rss+xml"/>
     ${items}

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -44,7 +44,7 @@ export async function generateMetadata({
           url: ogImageUrl,
           width: 1200,
           height: 630,
-          alt: "Pau Bartrina – Senior Frontend Engineer",
+          alt: "Pau Bartrina – Senior Software Engineer",
         },
       ],
     },

--- a/src/app/[locale]/contacte/page.tsx
+++ b/src/app/[locale]/contacte/page.tsx
@@ -32,7 +32,7 @@ export async function generateMetadata({
       description: t("description"),
       url: canonicalUrl,
       type: "website",
-      images: [{ url: OG_IMAGE, width: 1200, height: 630, alt: "Pau Bartrina – Senior Frontend Engineer" }],
+      images: [{ url: OG_IMAGE, width: 1200, height: 630, alt: "Pau Bartrina – Senior Software Engineer" }],
     },
     twitter: {
       card: "summary_large_image",

--- a/src/app/[locale]/cv/page.tsx
+++ b/src/app/[locale]/cv/page.tsx
@@ -80,7 +80,7 @@ export default async function CVPage({ params }: PageProps) {
           Pau Bartrina
         </h1>
         <p className="mt-1 font-mono text-lg text-text-accent">
-          Senior Frontend Engineer
+          {t("role")}
         </p>
         <div className="mt-3 flex flex-wrap gap-x-6 gap-y-1 font-mono text-sm text-text-secondary">
           <a href="https://paubartrina.cat" className="hover:underline print:no-underline">

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -63,7 +63,7 @@ export async function generateMetadata({
           url: ogImageUrl,
           width: 1200,
           height: 630,
-          alt: "Pau Bartrina – Senior Frontend Engineer",
+          alt: "Pau Bartrina – Senior Software Engineer",
         },
       ],
     },

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -30,7 +30,7 @@ export default async function Home({ params }: PageProps) {
     "@context": "https://schema.org",
     "@type": "Person",
     name: "Pau Bartrina",
-    jobTitle: "Front-end Web Developer",
+    jobTitle: "Senior Software Engineer",
     url: `https://paubartrina.cat/${locale}`,
     sameAs: [
       "https://bsky.app/profile/paubartrina.cat",

--- a/src/app/[locale]/uses/page.tsx
+++ b/src/app/[locale]/uses/page.tsx
@@ -39,7 +39,7 @@ export async function generateMetadata({
           url: ogImageUrl,
           width: 1200,
           height: 630,
-          alt: "Pau Bartrina – Senior Frontend Engineer",
+          alt: "Pau Bartrina – Senior Software Engineer",
         },
       ],
     },

--- a/src/i18n/messages/ca.json
+++ b/src/i18n/messages/ca.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "title": "Pau Bartrina | Senior Frontend Engineer",
+    "title": "Pau Bartrina | Enginyer de Software Sènior",
     "titleTemplate": "%s | Pau Bartrina",
-    "description": "Senior Frontend Engineer amb +15 anys d'experiència en Angular, TypeScript, NgRx i Nx. Especialitzat en arquitectura modular, testing i lideratge tècnic.",
+    "description": "Enginyer de Software Sènior amb +15 anys d'experiència en Angular, TypeScript, NgRx i Nx. Especialitzat en arquitectura modular, testing i lideratge tècnic.",
     "ogLocale": "ca_ES"
   },
   "nav": {
@@ -19,7 +19,7 @@
   },
   "hero": {
     "greeting": "Benvinguts",
-    "title": "Senior Frontend Engineer amb +15 anys d'experiència",
+    "title": "Enginyer de Software Sènior amb +15 anys d'experiència",
     "subtitle": "en l'ecosistema Angular, arquitectura modular i lideratge tècnic",
     "techBadges": [
       "Angular",
@@ -32,7 +32,7 @@
   },
   "about": {
     "heading": "Sobre Mi",
-    "bio": "Enginyer Frontend Sènior i Líder Tècnic amb més de 15 anys d'experiència, especialitzat en l'ecosistema Angular (NgRx, Nx, TypeScript). Expert en modernització de codis base i en la implementació de cultures de testing amb Vitest i Playwright. Líder col·laboratiu dedicat a connectar disseny, producte i enginyeria per oferir experiències d'usuari impecables.",
+    "bio": "Enginyer de Software Sènior i Líder Tècnic amb més de 15 anys d'experiència, especialitzat en l'ecosistema Angular (NgRx, Nx, TypeScript). Expert en modernització de codis base i en la implementació de cultures de testing amb Vitest i Playwright. Líder col·laboratiu dedicat a connectar disseny, producte i enginyeria per oferir experiències d'usuari impecables.",
     "languagesLabel": "Idiomes",
     "languages": [
       {
@@ -404,7 +404,7 @@
     "heading": "Què faig ara",
     "lastUpdated": "Última actualització: {date}",
     "location": "Visc a <strong>Sant Pere de Vilamajor</strong>, a la part baixa del <strong>Montseny</strong>.",
-    "occupation": "Sóc <code>programador web front-end</code> i actualment treballo en una empresa de producte del sector salut.",
+    "occupation": "Sóc <code>enginyer de software</code> i actualment treballo en una empresa de producte del sector salut.",
     "prioritiesHeading": "Les meves prioritats i l'estat dels projectes",
     "priorities": [
       "Des de l'última vegada que vaig actualitzar aquesta pàgina he passat per <strong>tres feines</strong>. La primera, una empresa de producte capdavantera del sector mecànic, em va acomiadar en període de prova als quatre mesos i sense cap mena d'explicació. La segona, una gran consultora, amb un client caòtic i un sou per sota del que tocava. La tercera és on sóc ara: una empresa de producte del <strong>sector salut</strong>, i aquí m'hi quedo.",
@@ -447,8 +447,9 @@
   },
   "cv": {
     "title": "CV — Pau Bartrina",
+    "role": "Enginyer de Software Sènior",
     "summaryHeading": "Resum",
-    "description": "CV imprimible de Pau Bartrina, Senior Frontend Engineer.",
+    "description": "CV imprimible de Pau Bartrina, Enginyer de Software Sènior.",
     "printButton": "Imprimir / Desar com a PDF",
     "backHome": "Tornar a l'inici"
   },

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "title": "Pau Bartrina | Senior Frontend Engineer",
+    "title": "Pau Bartrina | Senior Software Engineer",
     "titleTemplate": "%s | Pau Bartrina",
-    "description": "Senior Frontend Engineer with 15+ years of experience in Angular, TypeScript, NgRx, and Nx. Specializing in modular architecture, testing, and technical leadership.",
+    "description": "Senior Software Engineer with 15+ years of experience in Angular, TypeScript, NgRx, and Nx. Specializing in modular architecture, testing, and technical leadership.",
     "ogLocale": "en_US"
   },
   "nav": {
@@ -19,7 +19,7 @@
   },
   "hero": {
     "greeting": "Welcome",
-    "title": "Senior Frontend Engineer with 15+ years of experience",
+    "title": "Senior Software Engineer with 15+ years of experience",
     "subtitle": "in the Angular ecosystem, modular architecture, and technical leadership",
     "techBadges": [
       "Angular",
@@ -32,7 +32,7 @@
   },
   "about": {
     "heading": "About Me",
-    "bio": "Senior Frontend Engineer and Tech Lead with over 15 years of experience, specializing in the Angular ecosystem (NgRx, Nx, TypeScript). Expert in codebase modernization and implementing testing cultures with Vitest and Playwright. A collaborative leader dedicated to connecting design, product, and engineering to deliver flawless user experiences.",
+    "bio": "Senior Software Engineer and Tech Lead with over 15 years of experience, specializing in the Angular ecosystem (NgRx, Nx, TypeScript). Expert in codebase modernization and implementing testing cultures with Vitest and Playwright. A collaborative leader dedicated to connecting design, product, and engineering to deliver flawless user experiences.",
     "languagesLabel": "Languages",
     "languages": [
       {
@@ -404,7 +404,7 @@
     "heading": "What I'm doing now",
     "lastUpdated": "Last updated: {date}",
     "location": "I live in <strong>Sant Pere de Vilamajor</strong>, at the foot of <strong>Montseny</strong>.",
-    "occupation": "I'm a <code>front-end web developer</code> and I currently work at a product company in the health sector.",
+    "occupation": "I'm a <code>software engineer</code> and I currently work at a product company in the health sector.",
     "prioritiesHeading": "My priorities and project status",
     "priorities": [
       "Since I last updated this page I've been through <strong>three jobs</strong>. The first, a leading product company in the mechanical sector, let me go during my probation period after four months, with no explanation whatsoever. The second, a huge consultancy, with a chaotic client and a salary below what the work was worth. The third is where I am now: a product company in the <strong>health sector</strong>, and this is where I'm staying.",
@@ -447,8 +447,9 @@
   },
   "cv": {
     "title": "CV — Pau Bartrina",
+    "role": "Senior Software Engineer",
     "summaryHeading": "Summary",
-    "description": "Printable CV for Pau Bartrina, Senior Frontend Engineer.",
+    "description": "Printable CV for Pau Bartrina, Senior Software Engineer.",
     "printButton": "Print / Save as PDF",
     "backHome": "Back to home"
   },

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "title": "Pau Bartrina | Senior Frontend Engineer",
+    "title": "Pau Bartrina | Ingeniero de Software Sénior",
     "titleTemplate": "%s | Pau Bartrina",
-    "description": "Senior Frontend Engineer con +15 años de experiencia en Angular, TypeScript, NgRx y Nx. Especializado en arquitectura modular, testing y liderazgo técnico.",
+    "description": "Ingeniero de Software Sénior con +15 años de experiencia en Angular, TypeScript, NgRx y Nx. Especializado en arquitectura modular, testing y liderazgo técnico.",
     "ogLocale": "es_ES"
   },
   "nav": {
@@ -19,7 +19,7 @@
   },
   "hero": {
     "greeting": "Bienvenidos",
-    "title": "Senior Frontend Engineer con +15 años de experiencia",
+    "title": "Ingeniero de Software Sénior con +15 años de experiencia",
     "subtitle": "en el ecosistema Angular, arquitectura modular y liderazgo técnico",
     "techBadges": [
       "Angular",
@@ -32,7 +32,7 @@
   },
   "about": {
     "heading": "Sobre Mí",
-    "bio": "Ingeniero Frontend Sénior y Líder Técnico con más de 15 años de experiencia, especializado en el ecosistema Angular (NgRx, Nx, TypeScript). Experto en modernización de bases de código y en la implementación de culturas de testing con Vitest y Playwright. Líder colaborativo dedicado a conectar diseño, producto e ingeniería para ofrecer experiencias de usuario impecables.",
+    "bio": "Ingeniero de Software Sénior y Líder Técnico con más de 15 años de experiencia, especializado en el ecosistema Angular (NgRx, Nx, TypeScript). Experto en modernización de bases de código y en la implementación de culturas de testing con Vitest y Playwright. Líder colaborativo dedicado a conectar diseño, producto e ingeniería para ofrecer experiencias de usuario impecables.",
     "languagesLabel": "Idiomas",
     "languages": [
       {
@@ -404,7 +404,7 @@
     "heading": "Qué hago ahora",
     "lastUpdated": "Última actualización: {date}",
     "location": "Vivo en <strong>Sant Pere de Vilamajor</strong>, en la parte baja del <strong>Montseny</strong>.",
-    "occupation": "Soy <code>programador web front-end</code> y actualmente trabajo en una empresa de producto del sector salud.",
+    "occupation": "Soy <code>ingeniero de software</code> y actualmente trabajo en una empresa de producto del sector salud.",
     "prioritiesHeading": "Mis prioridades y el estado de los proyectos",
     "priorities": [
       "Desde la última vez que actualicé esta página he pasado por <strong>tres trabajos</strong>. El primero, una empresa de producto puntera del sector mecánico, me despidió en periodo de prueba a los cuatro meses y sin ningún tipo de explicación. El segundo, una gran consultora, con un cliente caótico y un sueldo por debajo de lo que tocaba. El tercero es donde estoy ahora: una empresa de producto del <strong>sector salud</strong>, y aquí me quedo.",
@@ -447,8 +447,9 @@
   },
   "cv": {
     "title": "CV — Pau Bartrina",
+    "role": "Ingeniero de Software Sénior",
     "summaryHeading": "Resumen",
-    "description": "CV imprimible de Pau Bartrina, Senior Frontend Engineer.",
+    "description": "CV imprimible de Pau Bartrina, Ingeniero de Software Sénior.",
     "printButton": "Imprimir / Guardar como PDF",
     "backHome": "Volver al inicio"
   },


### PR DESCRIPTION
Updates the current-role wording site-wide.

## Wording

| Locale | Title | Casual form (used in `/now`) |
|---|---|---|
| ca | Enginyer de Software Sènior | `enginyer de software` |
| es | Ingeniero de Software Sénior | `ingeniero de software` |
| en | Senior Software Engineer | `software engineer` |

Catalan and Spanish now carry a localised title rather than the English one they used before. Title Case for headline titles, lowercase in running sentences.

## Where it changed (11 files)

Page titles, meta descriptions, hero line, bio, the `/now` occupation line, the CV header, JSON-LD `jobTitle` (still read "Front-end Web Developer"), the RSS feed description, and five Open Graph alt texts.

## Deliberately unchanged

These are factual record, not current identity — changing them would rewrite employment history and put words in other people's mouths:

- Past job titles under Experience: `Senior R&D Engineer`, `Senior Front-end Architect & Developer`
- The descriptions of that past frontend work
- The testimonial quotes

## Drive-by improvement

The CV header rendered a hardcoded English string on all three locales. It now reads from a new `cv.role` key, so the Catalan and Spanish CVs finally show a localised title.

## Verification

`tsc --noEmit`, `lint`, 168 tests and `build` all pass. A sweep across all nine locale pages found zero remaining references to the old role outside the historical sections listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)